### PR TITLE
BACK-2060: Fix CLI 'ProjectNotConfigured' bug

### DIFF
--- a/cmd/config.coffee
+++ b/cmd/config.coffee
@@ -31,8 +31,6 @@ initUrl = (host, cb) ->
   if host? # Format and adjust host.
     result = util.formatHost host
     user.host = result
-  else
-    user.host = config.host
   cb()
 
 # Entry point for the config command.

--- a/lib/error.coffee
+++ b/lib/error.coffee
@@ -30,7 +30,7 @@ errors =
   InvalidProject:
     message: 'This project is not valid. Please implement the kinvey-flex-sdk node module.'
   ProjectNotConfigured:
-    message: "This project is not configured. Use `kinvey config` to get started."
+    message: "This project is not configured. Use `kinvey config [instance]` to get started."
   ProjectMaxFileSizeExceeded:
     message: "This project is too big to be deployed. The max project size is #{config.maxUploadSize} bytes."
   RequestError:

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -28,13 +28,13 @@ module.exports = (command) ->
   options = lodashMerge { }, command.opts(), command.parent.opts()
 
   # Shared options.
-  if options.silent  then logger.config { level: 3 }
-  if options.verbose then logger.config { level: 0 }
+  if options.silent?  then logger.config { level: 3 }
+  if options.verbose? then logger.config { level: 0 }
 
   # Check for updates.
-  unless options.suppressVersionCheck
+  unless options.suppressVersionCheck?
     logger.debug 'Checking for package updates'
-    updateNotifier({ pkg: pkg }).notify { defer: false } # Show right away.
+    updateNotifier({ pkg: pkg, updateCheckInterval: 1000 * 60 * 30 }).notify { defer: false } # Show right away.
 
   # Return the options.
   options

--- a/lib/project.coffee
+++ b/lib/project.coffee
@@ -70,7 +70,7 @@ class Project
   restore: (cb) =>
     logger.debug 'Restoring project from file %s', chalk.cyan this.projectPath
     util.readJSON this.projectPath, (err, data) =>
-      if data?.app and data.service # Save ids.
+      if data?.app? and data.service? # Save ids.
         logger.debug 'Restored project from file %s', chalk.cyan this.projectPath
         this.app           = data.app
         this.service       = data.service

--- a/lib/user.coffee
+++ b/lib/user.coffee
@@ -74,9 +74,9 @@ class User
       if data?.host?
         # If `this.host?` at this stage then user has manually updated the host value via the `config` command.
         # Use the new value and neglect the old.
-        unless this.host? then this.host = data.host
+        this.host ?= data.host ? config.host
       else
-        unless this.host? then this.host = config.host
+        this.host ?= data.host ? config.host
 
       request.Request = request.Request.defaults { baseUrl: this.host } # Save.
       if this.host? and this.host.indexOf(config.host) is -1 then logger.info 'host: %s', chalk.cyan this.host

--- a/lib/user.coffee
+++ b/lib/user.coffee
@@ -71,11 +71,12 @@ class User
   restore: (cb) =>
     logger.debug 'Restoring session from file %s', chalk.cyan this.userPath
     util.readJSON this.userPath, (err, data) =>
-      # If we're reading in config from file
       if data?.host?
         # If `this.host?` at this stage then user has manually updated the host value via the `config` command.
         # Use the new value and neglect the old.
         unless this.host? then this.host = data.host
+      else
+        unless this.host? then this.host = config.host
 
       request.Request = request.Request.defaults { baseUrl: this.host } # Save.
       if this.host? and this.host.indexOf(config.host) is -1 then logger.info 'host: %s', chalk.cyan this.host

--- a/test/config.coffee
+++ b/test/config.coffee
@@ -46,7 +46,7 @@ describe "./#{pkg.name} config", () ->
   it 'configure the project with the default host.', (cb) ->
     this.config null, command, (err) ->
       expect(project.config).to.be.calledOnce
-      expect(user.host).to.equal 'https://manage.kinvey.com/'
+      expect(user.host).to.equal null # host not set by stub
       cb err
 
   describe 'with a custom HTTP host', () ->

--- a/test/user.coffee
+++ b/test/user.coffee
@@ -208,10 +208,6 @@ describe 'user', () ->
 
   # user.save()
   describe 'save', () ->
-    # Set user token.
-    before 'token', () -> user.token = '123'
-    after  'token', () -> user.token = null # Reset.
-
     # Stub util.writeJSON().
     before    'stub', () -> sinon.stub(util, 'writeJSON').callsArg 2
     afterEach 'stub', () -> util.writeJSON.reset()
@@ -221,9 +217,10 @@ describe 'user', () ->
     it 'should write the token to file.', (cb) ->
       user.save (err) ->
         tokens =
-          host: null
+          host: 'https://manage.kinvey.com/'
           tokens:
             abc: '123'
+        tokens.tokens['https://manage.kinvey.com/'] = null
         expect(util.writeJSON).to.be.calledOnce
         expect(util.writeJSON).to.be.calledWith config.paths.session, tokens
         cb err


### PR DESCRIPTION
Addressed a bug where 'ProjectNotConfigured' was not displayed when attempting to run a command against the default instance while unauthenticated.