### PR TITLE
BACK-1883: Add support for choosing services from an organization 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 `npm install -g kinvey-cli`
 
 ## Usage
-In your project directory, run `kinvey config` to set-up your project. The CLI will prompt for Kinvey credentials, app, and Internal Flex Service.
+In your project directory, run `kinvey config` to set-up your project. The CLI will prompt for Kinvey credentials, app or organization, and Internal Flex Service.
 
 ### Commands
 * `config [instance]` - set project options (including optional dedicated Kinvey instance name)

--- a/lib/error.coffee
+++ b/lib/error.coffee
@@ -37,8 +37,10 @@ errors =
     message: 'There was an error processing your request.'
   NoAppsFound:
     message: 'You have no apps yet. Head over to the console to create one.'
-  NoDatalinksFound:
-    message: 'You have no eligible datalinks yet.'
+  NoFlexServicesFound:
+    message: 'You have no eligible Internal Flex Services yet.'
+  NoOrgsFound:
+    message: 'You have no organizations yet. Head over to the console to create one.'
   NoServiceHostsFound:
     message: 'There are no logs for this Internal Flex Service'
 

--- a/lib/project.coffee
+++ b/lib/project.coffee
@@ -31,6 +31,7 @@ class Project
 
   # App, service, and schema.
   app           : null
+  org           : null
   service       : null
   serviceName   : null
   schemaVersion : null
@@ -46,7 +47,7 @@ class Project
 
   # Returns whether the project is configured.
   isConfigured: () =>
-    this.app? and this.service? and this.schemaVersion?
+    return (this.app? or this.org?) and (this.service? and this.schemaVersion?)
 
   # Lists all Kinvey datalinks.
   list: (cb) =>
@@ -70,9 +71,10 @@ class Project
   restore: (cb) =>
     logger.debug 'Restoring project from file %s', chalk.cyan this.projectPath
     util.readJSON this.projectPath, (err, data) =>
-      if data?.app and data.service # Save ids.
+      if (data?.app or data?.org) and data.service # Save ids.
         logger.debug 'Restored project from file %s', chalk.cyan this.projectPath
         this.app           = data.app
+        this.org           = data.org
         this.service       = data.service
         this.serviceName   = data.serviceName
         this.schemaVersion = data.schemaVersion
@@ -87,6 +89,7 @@ class Project
     logger.debug 'Saving project to file %s', chalk.cyan this.projectPath
     util.writeJSON this.projectPath, {
       app           : this.app
+      org           : this.org
       service       : this.service
       serviceName   : this.serviceName
       schemaVersion : this.schemaVersion
@@ -96,7 +99,7 @@ class Project
   # Selects and save app, and service.
   select: (cb) =>
     async.series [
-      this._selectApp
+      this._selectAppOrOrg
       this._selectService
       this.save
     ], cb
@@ -124,14 +127,26 @@ class Project
           if x.name.toLowerCase() < y.name.toLowerCase() then -1 else 1
         cb null, body
 
+  # Executes a GET /apps request.
+  _execOrgs: (cb) ->
+    util.makeRequest { url: '/organizations' }, (err, response) ->
+      cb err, response?.body
+
   # Executes a GET /apps/:app/datalinks request.
   _execServices: (cb) ->
+    if this.org?
+      resourceType = 'organizations'
+      entity = this.org
+    else
+      resourceType = 'apps'
+      entity = this.app
+
     util.makeRequest {
-      url: "/v#{this.schemaVersion}/apps/#{this.app}/data-links"
+      url: "/v#{this.schemaVersion}/#{resourceType}/#{entity}/data-links"
     }, (err, response) ->
       cb err, response?.body
 
-  # Attempts to select the app.
+  # Attempts to select an app.
   _selectApp: (cb) =>
     async.waterfall [
       this._execApps
@@ -140,8 +155,34 @@ class Project
         else prompt.getApp apps, next
     ], (err, app) =>
       if app? # Save.
+        this.org           = null
         this.app           = app.id
         this.schemaVersion = app.schemaVersion or config.defaultSchemaVersion
+      cb err # Continue.
+
+  # Prompts user to select an app or organization.
+  _selectAppOrOrg: (cb) =>
+    options = [{
+      name: 'App'
+    }, {
+      name: 'Organization'
+    }]
+    prompt.getAppOrOrg options, (err, choice) =>
+      if choice.name is 'App' then this._selectApp cb
+      else this._selectOrg cb
+
+  # Attempts to select an org.
+  _selectOrg: (cb) =>
+    async.waterfall [
+      this._execOrgs
+      (orgs, next) ->
+        if 0 is orgs.length then next new KinveyError 'NoOrgsFound'
+        else prompt.getOrg orgs, next
+    ], (err, org) =>
+      if org? # Save.
+        this.app           = null
+        this.org           = org.id
+        this.schemaVersion = 2 # TODO fix this
       cb err # Continue.
 
   # Attempts to select the service
@@ -149,7 +190,7 @@ class Project
     async.waterfall [
       this._execKinveyServices
       (services, next) ->
-        if 0 is services.length then next new KinveyError 'NoDatalinksFound'
+        if 0 is services.length then next new KinveyError 'NoFlexServicesFound'
         else prompt.getService services, next
     ], (err, service) =>
       if service?

--- a/lib/prompt.coffee
+++ b/lib/prompt.coffee
@@ -40,6 +40,30 @@ exports.getApp = (apps, cb) ->
   }], (answers) ->
     cb null, answers.app # Continue.
 
+# Prompts the user for the app to use.
+exports.getAppOrOrg = (options, cb) ->
+  logger.debug 'Prompting for app or organization'
+  inquirer.prompt [{
+    message : 'Would you like to select a service from a Kinvey app or org?'
+    name    : 'option'
+    type    : 'list'
+    choices : util.formatList options
+    when    : 0 < options.length
+  }], (answers) ->
+    cb null, answers.option # Continue.
+
+# Prompts the user for the app to use.
+exports.getOrg = (orgs, cb) ->
+  logger.debug 'Prompting for organization'
+  inquirer.prompt [{
+    message : 'Which organization would you like to use?'
+    name    : 'org'
+    type    : 'list'
+    choices : util.formatList orgs
+    when    : 0 < orgs.length
+  }], (answers) ->
+    cb null, answers.org # Continue.
+
 # Prompts the user for the service to use.
 exports.getService = (services, cb) ->
   logger.debug 'Prompting for service'

--- a/test/fixtures/org.json
+++ b/test/fixtures/org.json
@@ -1,0 +1,14 @@
+{
+  "name": "TestOrg",
+  "creator": "39229488331a4af9046486a9bbfa5e8e",
+  "creationTime": "2016-11-01T05:47:56.247Z",
+  "restrictions": {
+    "defaultPlanLevel": "development"
+  },
+  "security": {
+    "requireApprovals": false,
+    "requireEmailVerification": false,
+    "requireTwoFactorAuth": false
+  },
+  "id": "123"
+}


### PR DESCRIPTION
Sample output and example of new flow:

```Sams-MacBook-Pro:basicDlc sam$ cli.js config http://localhost:8888
info:  host: http://localhost:8888/
? E-mail sam@kinvey.com
? Password ********
info:  Welcome back sam@kinvey.com
? Would you like to select a service from a Kinvey app or org? Organization
? Which org would you like to use? my-org
? Which service would you like to use? my-link
Sams-MacBook-Pro:basicDlc sam$ cli.js status
info:  host: http://localhost:8888/
info:  Service status: NEW
Sams-MacBook-Pro:basicDlc sam$```