### PR TITLE
BACK-2190: Add protection for parsing/displaying malformed FSR log messages

### DIFF
--- a/lib/service.coffee
+++ b/lib/service.coffee
@@ -120,12 +120,17 @@ class Service
     this._execDatalinkLogs from, to, (err, logs) ->
       if err? then cb err # Continue with error.
       else # Log info.
+        skippedLogEntries = 0
         logs.forEach (log) ->
-          if log.threshold?
-            console.log '[%s] %s %s - %s', log.threshold, chalk.green(log.containerId.substring(0, 12)), log.timestamp, chalk.cyan(log.message.trim())
+          if log?.message?
+            if log.threshold?
+              console.log '[%s] %s %s - %s', log.threshold, chalk.green(log.containerId.substring(0, 12)), log.timestamp, chalk.cyan(log.message.trim())
+            else
+              console.log '%s %s - %s', chalk.green(log.containerId.substring(0, 12)), log.timestamp, chalk.cyan(log.message.trim())
           else
-            console.log '%s %s - %s', chalk.green(log.containerId.substring(0, 12)), log.timestamp, chalk.cyan(log.message.trim())
-        console.log 'Query returned %s logs for FSR service %s (%s)', chalk.cyan(logs.length), chalk.cyan(project.service),
+            skippedLogEntries++
+            log.skipped = true
+        console.log 'Query returned %s logs for FSR service %s (%s)', chalk.cyan(logs.length - skippedLogEntries), chalk.cyan(project.service),
           chalk.gray(project.serviceName)
         cb null, logs # Continue.
 

--- a/lib/service.coffee
+++ b/lib/service.coffee
@@ -120,7 +120,7 @@ class Service
     this._execDatalinkLogs from, to, (err, logs) ->
       if err? then cb err # Continue with error.
       else # Log info.
-        skippedLogEntries = 0
+        skippedLogEntries = []
         logs.forEach (log) ->
           if log?.message?
             if log.threshold?
@@ -128,10 +128,10 @@ class Service
             else
               console.log '%s %s - %s', chalk.green(log.containerId.substring(0, 12)), log.timestamp, chalk.cyan(log.message.trim())
           else
-            skippedLogEntries++
             log.skipped = true
-        console.log 'Query returned %s logs for FSR service %s (%s)', chalk.cyan(logs.length - skippedLogEntries), chalk.cyan(project.service),
-          chalk.gray(project.serviceName)
+            skippedLogEntries.push log
+        if skippedLogEntries.length > 0 then logger.debug '%s skipped log entries for FSR service %s (%s): %s', skippedLogEntries.length, project.service, project.serviceName, JSON.stringify(skippedLogEntries)
+        console.log 'Query returned %s logs for FSR service %s (%s)', chalk.cyan(logs.length - skippedLogEntries.length), chalk.cyan(project.service), chalk.gray(project.serviceName)
         cb null, logs # Continue.
 
   # Recycles the containers that host the DLC.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "mocha": "2.3.3",
     "nock": "2.12.0",
     "sinon": "1.17.0",
-    "sinon-chai": "2.8.0"
+    "sinon-chai": "2.8.0",
+    "test-console": "1.0.0"
   },
   "engines": {
     "node": ">=6.x.x"

--- a/test/service.coffee
+++ b/test/service.coffee
@@ -306,6 +306,30 @@ describe 'service', () ->
             expect(logs[0].containerId).to.equal this.containerId
             cb err
 
+      describe 'with an undefined message in a result object', () ->
+        # Mock the API.
+        beforeEach 'api', () ->
+          this.mock = api.get "/v#{project.schemaVersion}/data-links/#{project.service}/logs"
+            .reply 200, [
+              {
+                threshold: 'info'
+                timestamp: new Date().toISOString()
+                containerId: this.containerId
+              }
+            ]
+        afterEach 'api', () ->
+          this.mock.done()
+          delete this.mock
+
+        # Tests.
+        it 'should not return any logs.', (cb) ->
+          service.logs null, null, (err, logs) =>
+            expect(logs[0].threshold).to.equal 'info'
+            expect(logs[0].message).not.to.exist
+            expect(logs[0].containerId).to.equal this.containerId
+            expect(logs[0].skipped).to.equal true # entry was skipped due to lack of valid `message` property
+            cb err
+
   # service.validate().
   describe 'validate', () ->
     # Configure.

--- a/test/service.coffee
+++ b/test/service.coffee
@@ -22,8 +22,9 @@ path = require 'path'
 
 # Local modules.
 api      = require './lib/api.coffee'
-service = require '../lib/service.coffee'
+logger   = require '../lib/logger'
 project  = require '../lib/project.coffee'
+service  = require '../lib/service.coffee'
 util     = require '../lib/util.coffee'
 
 # Configure.
@@ -307,6 +308,12 @@ describe 'service', () ->
             cb err
 
       describe 'with an undefined message in a result object', () ->
+        before 'log level', () ->
+          logger.config { level: 0 } # Verbose for this test
+
+        after 'log level', () ->
+          logger.config { level: 3 } # Silent afterward
+
         # Mock the API.
         beforeEach 'api', () ->
           this.mock = api.get "/v#{project.schemaVersion}/data-links/#{project.service}/logs"


### PR DESCRIPTION
This PR adds two features surrounding logging:

- Stringify log messages that are not previously stringified server-side
- When processing and printing server-side log results, skip messages (and add trace code for this when CLI is run in verbose mode) when `message` property is missing