### PR TITLE
BACK-2440: Set default host when config file does not exist

### DIFF
--- a/lib/user.coffee
+++ b/lib/user.coffee
@@ -71,12 +71,11 @@ class User
   restore: (cb) =>
     logger.debug 'Restoring session from file %s', chalk.cyan this.userPath
     util.readJSON this.userPath, (err, data) =>
-      if data?.host?
-        # If `this.host?` at this stage then user has manually updated the host value via the `config` command.
-        # Use the new value and neglect the old.
-        this.host ?= data.host ? config.host
+      if err? then this.host = config.host
       else
-        this.host ?= data.host ? config.host
+        if data?.host? then this.host ?= data.host
+        else
+          this.host ?= config.host
 
       request.Request = request.Request.defaults { baseUrl: this.host } # Save.
       if this.host? and this.host.indexOf(config.host) is -1 then logger.info 'host: %s', chalk.cyan this.host

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -104,7 +104,7 @@ exports.readFile = readFile = (file, cb) ->
   fs.readFile file, cb # Forward to fs.
 
 # Reads JSON contents from the specified file.
-exports.readJSON = readJSON = (file, cb) ->
+exports.readJSON = (file, cb) ->
   logger.debug 'Reading JSON from file %s', chalk.cyan file # Debug.
   async.waterfall [
     (next)       -> readFile file, next
@@ -125,7 +125,7 @@ exports.writeFile = writeFile = (file, contents, cb) ->
   fs.writeFile file, contents, cb # Forward to fs.
 
 # Writes JSON contents to the specified file.
-exports.writeJSON = writeJSON = (file, json, cb) ->
+exports.writeJSON = (file, json, cb) ->
   logger.debug 'Writing JSON to file %s', chalk.cyan file # Debug.
   contents = JSON.stringify json
   writeFile file, contents, cb

--- a/test/user.coffee
+++ b/test/user.coffee
@@ -194,7 +194,7 @@ describe 'user', () ->
       after     'login', () -> user.login.restore()
 
       # Stub util.readJSON().
-      before    'readJSON', () -> sinon.stub(util, 'readJSON').callsArgWith 1, null, { }
+      before    'readJSON', () -> sinon.stub(util, 'readJSON').callsArgWith 1, new Error 'boom'
       afterEach 'readJSON', () -> util.readJSON.reset()
       after     'readJSON', () -> util.readJSON.restore()
 
@@ -203,7 +203,26 @@ describe 'user', () ->
         user.restore (err) ->
           expect(user.login).to.be.calledOnce
           expect(user.login).to.be.calledWith undefined, undefined
-          expect(user.token).to.be.null
+          expect(user.host).to.equal config.host
+          cb err
+
+    describe 'when the session file is empty', () ->
+      # Stub user.login().
+      before    'login', () -> sinon.stub(user, 'login').callsArg 2
+      afterEach 'login', () -> user.login.reset()
+      after     'login', () -> user.login.restore()
+
+      # Stub util.readJSON().
+      before    'readJSON', () -> sinon.stub(util, 'readJSON').callsArgWith 1, null, null
+      afterEach 'readJSON', () -> util.readJSON.reset()
+      after     'readJSON', () -> util.readJSON.restore()
+
+      # Tests.
+      it 'should login.', (cb) ->
+        user.restore (err) ->
+          expect(user.login).to.be.calledOnce
+          expect(user.login).to.be.calledWith undefined, undefined
+          expect(user.host).to.equal config.host
           cb err
 
   # user.save()


### PR DESCRIPTION
Fix bug where CLI errors when running `kinvey config` and the session file does not exist