### PR TITLE
BACK-2575: Fix bug where instance override was not honored

### DIFF
--- a/lib/user.coffee
+++ b/lib/user.coffee
@@ -71,11 +71,11 @@ class User
   restore: (cb) =>
     logger.debug 'Restoring session from file %s', chalk.cyan this.userPath
     util.readJSON this.userPath, (err, data) =>
-      if err? then this.host = config.host
-      else
-        if data?.host? then this.host ?= data.host
+      unless this.host? # this.host manually overridden by user
+        if err? then this.host = config.host # error retrieving saved value, use default
+        else if data?.host? then this.host ?= data.host # no override, use stored/configured value
         else
-          this.host ?= config.host
+          this.host ?= config.host # use default host (no call override, no stored value)
 
       request.Request = request.Request.defaults { baseUrl: this.host } # Save.
       if this.host? and this.host.indexOf(config.host) is -1 then logger.info 'host: %s', chalk.cyan this.host

--- a/test/user.coffee
+++ b/test/user.coffee
@@ -185,6 +185,7 @@ describe 'user', () ->
           expect(util.readJSON).to.be.calledOnce
           expect(util.readJSON).to.be.calledWith config.paths.session
           expect(user.getToken()).to.equal this.token
+          expect(user.host).to.equal this.host # Ensure value is not overridden
           cb err
 
     describe 'when the session file does not exist', () ->


### PR DESCRIPTION
`this.host` is set (prior to invocation of `restore`) if a custom instance is specified in the `config` command. This branch fixes a bug where the instance was set to default even if an override existed. Includes a test.