### PR TITLE
BACK-2644: Add 2FA support

### DIFF
--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -96,8 +96,32 @@ function getEmailPassword(email, password, cb) {
   });
 }
 
+function getTwoFactorToken(token, cb) {
+  logger.debug('Prompting for 2FA token');
+  return inquirer.prompt([
+    {
+      message: 'Two-factor authentication token',
+      name: 'mfaToken',
+      when: token == null,
+      validate: (value) => {
+        const result = 'Please enter a valid 2FA token (6 digits)';
+        if (value.length !== 6) return result;
+
+        const input = parseInt(value, 10);
+        if (!input) return result;
+
+        return true;
+      }
+    }
+  ], (answers) => {
+    if (answers.mfaToken != null) token = answers.mfaToken;
+    return cb(null, token);
+  });
+}
+
 exports.getApp = getApp;
 exports.getAppOrOrg = getAppOrOrg;
 exports.getOrg = getOrg;
 exports.getService = getService;
 exports.getEmailPassword = getEmailPassword;
+exports.getTwoFactorToken = getTwoFactorToken;

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -18,6 +18,11 @@ const isEmail = require('isemail');
 const logger = require('./logger.js');
 const util = require('./util.js');
 
+function validateMfaToken(value) {
+  if (/^\d{6}$/.test(value)) return true;
+  return 'Please enter a valid 2FA token (6 digits).';
+}
+
 function validateEmail(email) {
   if (isEmail(email)) return true;
   return 'Please enter a valid e-mail address.';
@@ -103,11 +108,7 @@ function getTwoFactorToken(token, cb) {
       message: 'Two-factor authentication token',
       name: 'mfaToken',
       when: token == null,
-      validate: (value) => {
-        const inputIsValid = (new RegExp('^\\d{6}$')).test(value);
-        if (inputIsValid) return true;
-        return 'Please enter a valid 2FA token (6 digits)';
-      }
+      validate: validateMfaToken
     }
   ], (answers) => {
     if (answers.mfaToken != null) token = answers.mfaToken;
@@ -121,3 +122,5 @@ exports.getOrg = getOrg;
 exports.getService = getService;
 exports.getEmailPassword = getEmailPassword;
 exports.getTwoFactorToken = getTwoFactorToken;
+exports.validateEmail = validateEmail;
+exports.validateMfaToken = validateMfaToken;

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -104,8 +104,8 @@ function getTwoFactorToken(token, cb) {
       name: 'mfaToken',
       when: token == null,
       validate: (value) => {
-        const result = (new RegExp('^\\d{6}$')).test(value);
-        if (result) return true;
+        const inputIsValid = (new RegExp('^\\d{6}$')).test(value);
+        if (inputIsValid) return true;
         return 'Please enter a valid 2FA token (6 digits)';
       }
     }

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -104,13 +104,9 @@ function getTwoFactorToken(token, cb) {
       name: 'mfaToken',
       when: token == null,
       validate: (value) => {
-        const result = 'Please enter a valid 2FA token (6 digits)';
-        if (value.length !== 6) return result;
-
-        const input = parseInt(value, 10);
-        if (!input) return result;
-
-        return true;
+        const result = (new RegExp("^\\d{6}$")).test(value);
+        if (result) return true;
+        else return 'Please enter a valid 2FA token (6 digits)';
       }
     }
   ], (answers) => {

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -104,9 +104,9 @@ function getTwoFactorToken(token, cb) {
       name: 'mfaToken',
       when: token == null,
       validate: (value) => {
-        const result = (new RegExp("^\\d{6}$")).test(value);
+        const result = (new RegExp('^\\d{6}$')).test(value);
         if (result) return true;
-        else return 'Please enter a valid 2FA token (6 digits)';
+        return 'Please enter a valid 2FA token (6 digits)';
       }
     }
   ], (answers) => {

--- a/lib/user.js
+++ b/lib/user.js
@@ -129,7 +129,7 @@ class User {
     }, cb);
   }
 
-  _mfaLogin(email, password, token, cb) {
+  mfaLogin(email, password, token, cb) {
     return async.doUntil((next) => {
       this._mfaLoginOnce(email, password, token, next);
     }, () => this.isLoggedIn(), cb);
@@ -160,7 +160,7 @@ class User {
         this._execLogin(email, password, null, next);
       }
     ], (err, response) => {
-      if (err != null && (err.name === 'InvalidTwoFactorAuth')) return this._mfaLogin(email, password, token, cb);
+      if (err != null && (err.name === 'InvalidTwoFactorAuth')) return this.mfaLogin(email, password, token, cb);
       else if (err != null && (err.name === 'InvalidCredentials' || err.name === 'ValidationError')) {
         return cb();
       } else if (err != null) {

--- a/lib/user.js
+++ b/lib/user.js
@@ -39,9 +39,9 @@ class User {
     return this.token;
   }
 
-  login(email, password, cb) {
+  login(email, password, token, cb) {
     return async.doUntil((next) => {
-      this._loginOnce(email, password, next);
+      this._loginOnce(email, password, token, next);
       return email = password = null;
     }, () => this.isLoggedIn(), cb);
   }
@@ -55,7 +55,7 @@ class User {
     if ((this.tokens != null) && (this.host != null)) this.tokens[this.host] = null;
     this.token = null;
     return async.series([
-      (next) => this.login(null, null, next),
+      (next) => this.login(null, null, null, next),
       (next) => this.save(next)
     ], (err) => cb(err)
     );
@@ -97,7 +97,7 @@ class User {
   }
 
   setup(options, cb) {
-    if ((options.email != null) || (options.password != null) || (options.host != null)) {
+    if ((options.email != null) || (options.password != null) || (options.host != null) || (options.token != null)) {
       if (options.host != null) {
         const host = util.formatHost(options.host);
         logger.debug(`Setting host: ${host}`);
@@ -109,43 +109,77 @@ class User {
       request.Request = request.Request.defaults({
         baseUrl: this.host
       });
-      return this.login(options.email, options.password, cb);
+      return this.login(options.email, options.password, options.token, cb);
     }
 
     return this.restore(cb);
   }
 
-  _execLogin(email, password, cb) {
+  _execLogin(email, password, token, cb) {
+    const jsonBody = {
+      email,
+      password
+    };
+    if (token != null) jsonBody.twoFactorToken = token;
     return util.makeRequest({
       method: 'POST',
       url: '/session',
-      json: {
-        email,
-        password
-      },
+      json: jsonBody,
       refresh: false
     }, cb);
   }
 
-  _loginOnce(email, password, cb) {
+  _mfaLogin(email, password, token, cb) {
+    return async.doUntil((next) => {
+      this._mfaLoginOnce(email, password, token, next);
+    }, () => this.isLoggedIn(), cb);
+  }
+
+  _mfaLoginOnce(email, password, token, cb) {
     return async.waterfall([
-      (next) => prompt.getEmailPassword(email, password, next),
-      (email, password, next) => this._execLogin(email, password, next)
+      (next) => prompt.getTwoFactorToken(token, next),
+      (key, next) => this._execLogin(email, password, key, next)
     ], (err, response) => {
-      if (err != null && (err.name === 'InvalidCredentials' || err.name === 'ValidationError')) {
+      if (err != null && (err.name === 'InvalidTwoFactorAuth')) {
+        logger.warn(err.message);
         return cb();
       } else if (err != null) {
         return cb(err);
       }
 
-      logger.info('Welcome back %s', chalk.cyan(response.body.email));
-      if (this.host != null) {
-        this.tokens[this.host] = response.body.token;
-      } else {
-        this.token = response.body.token;
-      }
-      return cb();
+      this.completeLogin(response, cb);
     });
+  }
+
+  _loginOnce(email, password, token, cb) {
+    return async.waterfall([
+      (next) => prompt.getEmailPassword(email, password, next),
+      (promptEmail, promptPassword, next) => {
+        email = promptEmail;
+        password = promptPassword;
+        this._execLogin(email, password, null, next);
+      }
+    ], (err, response) => {
+      if (err != null && (err.name === 'InvalidTwoFactorAuth')) return this._mfaLogin(email, password, token, cb);
+      else if (err != null && (err.name === 'InvalidCredentials' || err.name === 'ValidationError')) {
+        return cb();
+      } else if (err != null) {
+        return cb(err);
+      }
+
+      this.completeLogin(response, cb);
+    });
+  }
+
+  completeLogin(response, cb) {
+    logger.info('Welcome back %s', chalk.cyan(response.body.email));
+    if (this.host != null) {
+      this.tokens[this.host] = response.body.token;
+    } else {
+      this.token = response.body.token;
+    }
+
+    cb();
   }
 }
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,6 +1,5 @@
 --check-leaks
 --compilers coffee:coffee-script/register
---no-exit
 --recursive
 --reporter spec
 --require  ./test/lib/common.js

--- a/test/prompt.js
+++ b/test/prompt.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2017, Kinvey, Inc. All rights reserved.
+ *
+ * This software is licensed to you under the Kinvey terms of service located at
+ * http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+ * software, you hereby accept such terms of service  (and any agreement referenced
+ * therein) and agree that you have read, understand and agree to be bound by such
+ * terms of service and are of legal age to agree to such terms with Kinvey.
+ *
+ * This software contains valuable confidential and proprietary information of
+ * KINVEY, INC and is subject to applicable licensing agreements.
+ * Unauthorized reproduction, transmission or distribution of this file and its
+ * contents is a violation of applicable laws.
+ */
+
+const prompt = require('../lib/prompt');
+
+describe('prompt', () => {
+  it('should validate an email address', () => {
+    let result = prompt.validateEmail('abc');
+    expect(result).to.eql('Please enter a valid e-mail address.');
+    result = prompt.validateEmail('');
+    expect(result).to.eql('Please enter a valid e-mail address.');
+    result = prompt.validateEmail('abc@email.com');
+    expect(result).to.eql(true);
+  });
+  it('should validate a 2FA token', () => {
+    let result = prompt.validateMfaToken('abc');
+    expect(result).to.eql('Please enter a valid 2FA token (6 digits).');
+    result = prompt.validateMfaToken('abcdef');
+    expect(result).to.eql('Please enter a valid 2FA token (6 digits).');
+    result = prompt.validateMfaToken('123');
+    expect(result).to.eql('Please enter a valid 2FA token (6 digits).');
+    result = prompt.validateMfaToken('1234567');
+    expect(result).to.eql('Please enter a valid 2FA token (6 digits).');
+    result = prompt.validateMfaToken('_asdfaih#%$@NUG@A');
+    expect(result).to.eql('Please enter a valid 2FA token (6 digits).');
+    result = prompt.validateMfaToken('');
+    expect(result).to.eql('Please enter a valid 2FA token (6 digits).');
+    result = prompt.validateMfaToken('123456');
+    expect(result).to.eql(true);
+  });
+});

--- a/test/user.js
+++ b/test/user.js
@@ -68,7 +68,7 @@ describe('user', () => {
         return delete this.mock;
       });
       return it('should login.', (cb) => {
-        return user.login(this.email, this.password, (err) => {
+        return user.login(this.email, this.password, null, (err) => {
           expect(user.isLoggedIn()).to.be.true;
           expect(user.getToken()).to.equal(this.token);
           return cb(err);
@@ -103,7 +103,7 @@ describe('user', () => {
         return prompt.getEmailPassword.restore();
       });
       return it('should retry.', (cb) => {
-        return user.login('alice@example.com', this.password, (err) => {
+        return user.login('alice@example.com', this.password, null, (err) => {
           expect(prompt.getEmailPassword).to.be.calledTwice;
           expect(prompt.getEmailPassword).to.be.calledWith(null, null);
           return cb(err);
@@ -132,9 +132,9 @@ describe('user', () => {
         return prompt.getEmailPassword.restore();
       });
       return it('should prompt.', (cb) => {
-        return user.login(void 0, this.password, ((err) => {
+        return user.login(null, this.password, null, ((err) => {
           expect(prompt.getEmailPassword).to.be.calledOnce;
-          expect(prompt.getEmailPassword).to.be.calledWith(void 0, this.password);
+          expect(prompt.getEmailPassword).to.be.calledWith(null, this.password);
           return cb(err);
         }));
       });
@@ -166,7 +166,7 @@ describe('user', () => {
       return delete this.token;
     });
     before('login', () => {
-      return sinon.stub(user, 'login').callsArg(2);
+      return sinon.stub(user, 'login').callsArg(3);
     });
     afterEach('login', () => {
       return user.login.reset();
@@ -242,7 +242,7 @@ describe('user', () => {
     });
     describe('when the session file does not exist', () => {
       before('login', () => {
-        return sinon.stub(user, 'login').callsArg(2);
+        return sinon.stub(user, 'login').callsArg(3);
       });
       afterEach('login', () => {
         return user.login.reset();
@@ -271,7 +271,7 @@ describe('user', () => {
   });
   describe('when the session file is empty', () => {
     before('login', () => {
-      sinon.stub(user, 'login').callsArg(2);
+      sinon.stub(user, 'login').callsArg(3);
     });
     afterEach('login', () => {
       user.login.reset();
@@ -324,7 +324,7 @@ describe('user', () => {
   });
   describe('setup', () => {
     before('login', () => {
-      sinon.stub(user, 'login').callsArg(2);
+      sinon.stub(user, 'login').callsArg(3);
     });
     afterEach('login', () => {
       user.login.reset();
@@ -353,7 +353,7 @@ describe('user', () => {
       };
       user.setup(options, (err) => {
         expect(user.login).to.be.calledOnce;
-        expect(user.login).to.be.calledWith(options.email, void 0);
+        expect(user.login).to.be.calledWith(options.email, undefined, undefined);
         cb(err);
       });
     });
@@ -363,7 +363,7 @@ describe('user', () => {
       };
       user.setup(options, (err) => {
         expect(user.login).to.be.calledOnce;
-        expect(user.login).to.be.calledWith(void 0, options.password);
+        expect(user.login).to.be.calledWith(undefined, options.password, undefined);
         cb(err);
       });
     });


### PR DESCRIPTION
Adds 2FA support to the Kinvey CLI. If an login request succeeds with a set of credentials but is rejected due to an invalid 2FA token, the error is suppressed and a prompt is displayed for a token. This token is included with the original credentials on the second login attempt.