### PR TITLE
BACK-2804: Initial refactor of logs command

### DIFF
--- a/cmd/logs.js
+++ b/cmd/logs.js
@@ -59,7 +59,7 @@ program
   .command('logs')
   .option('--start <string>', 'fetch logs starting from provided timestamp')
   .option('--end <string>', 'fetch log entries up to provided timestamp')
-  .option('--page <number>', 'page (default=0)')
+  .option('--page <number>', 'page (default=1)')
   .option('-n, --number <number>', `number of entries to fetch, i.e. page size (default=${config.logFetchDefault}, max=${config.logFetchMax}`)
   .description('retrieve and display Internal Flex Service logs')
   .action(logs);

--- a/cmd/logs.js
+++ b/cmd/logs.js
@@ -23,13 +23,14 @@ const logger = require('../lib/logger.js');
 const project = require('../lib/project.js');
 const user = require('../lib/user.js');
 const handleActionFailure = require('./../lib/util').handleCommandFailure;
+const LogErrorMessages = require('../lib/constants').LogErrorMessages;
 
-function validateTimestamp(ts) {
+function isValidTimestamp(ts) {
   if (ts == null) return true;
   return moment(ts, moment.ISO_8601, true).isValid();
 }
 
-function validateNumber(number) {
+function isValidNonZeroInteger(number) {
   if (number == null) return true;
   if (number === 0 || number === '0') return false;
   return /^\d+$/.test(number);
@@ -39,10 +40,10 @@ function logs(command, cb) {
   const options = init(command);
 
   // Validate input parameters
-  if (!validateTimestamp(options.start)) return handleActionFailure(new Error('Logs \'start\' timestamp invalid (ISO-8601 expected)'), cb);
-  if (!validateTimestamp(options.end)) return handleActionFailure(new Error('Logs \'end\' timestamp invalid (ISO-8601 expected)'), cb);
-  if (!validateNumber(options.number)) return handleActionFailure(new Error('Logs \'number\' parameter invalid (non-zero integer expected)'), cb);
-  if (!validateNumber(options.page)) return handleActionFailure(new Error('Logs \'page\' parameter invalid (non-zero integer expected)'), cb);
+  if (!isValidTimestamp(options.start)) return handleActionFailure(new Error(`Logs \'start\' ${LogErrorMessages.INVALID_TIMESTAMP}`), cb);
+  if (!isValidTimestamp(options.end)) return handleActionFailure(new Error(`Logs \'end\' ${LogErrorMessages.INVALID_TIMESTAMP}`), cb);
+  if (!isValidNonZeroInteger(options.number)) return handleActionFailure(new Error(`Logs \'number\' ${LogErrorMessages.INVALID_NONZEROINT}`), cb);
+  if (!isValidNonZeroInteger(options.page)) return handleActionFailure(new Error(`Logs \'page\' ${LogErrorMessages.INVALID_NONZEROINT}`), cb);
 
   return async.series([
     (next) => user.setup(options, next),

--- a/cmd/logs.js
+++ b/cmd/logs.js
@@ -41,8 +41,8 @@ function logs(command, cb) {
   // Validate input parameters
   if (!validateTimestamp(options.start)) return handleActionFailure(new Error('Logs \'start\' timestamp invalid (ISO-8601 expected)'), cb);
   if (!validateTimestamp(options.end)) return handleActionFailure(new Error('Logs \'end\' timestamp invalid (ISO-8601 expected)'), cb);
-  if (!validateNumber(options.number)) return handleActionFailure(new Error('Logs \'number\' parameter invalid (integer expected)'), cb);
-  if (!validateNumber(options.page)) return handleActionFailure(new Error('Logs \'page\' parameter invalid (integer expected)'), cb);
+  if (!validateNumber(options.number)) return handleActionFailure(new Error('Logs \'number\' parameter invalid (non-zero integer expected)'), cb);
+  if (!validateNumber(options.page)) return handleActionFailure(new Error('Logs \'page\' parameter invalid (non-zero integer expected)'), cb);
 
   return async.series([
     (next) => user.setup(options, next),
@@ -57,9 +57,9 @@ module.exports = logs;
 
 program
   .command('logs')
-  .option('--start <string>', 'fetch logs starting from provided timestamp')
+  .option('--start <string>', 'fetch log entries starting from provided timestamp')
   .option('--end <string>', 'fetch log entries up to provided timestamp')
-  .option('--page <number>', 'page (default=1)')
-  .option('-n, --number <number>', `number of entries to fetch, i.e. page size (default=${config.logFetchDefault}, max=${config.logFetchMax}`)
+  .option('--page <number>', 'page (non-zero integer, default=1)')
+  .option('-n, --number <number>', `number of entries to fetch, i.e. page size (non-zero integer, default=${config.logFetchDefault}, max=${config.logFetchLimit})`)
   .description('retrieve and display Internal Flex Service logs')
   .action(logs);

--- a/config/default.js
+++ b/config/default.js
@@ -18,6 +18,8 @@ const osHomedir = require('os-homedir');
 
 module.exports = {
   host: 'https://manage.kinvey.com/',
+  logFetchDefault: 100,
+  logFetchLimit: 2500,
   defaultSchemaVersion: 2,
   artifacts: ['.git', '.svn', 'node_modules', 'output.log'],
   maxUploadSize: 10 * 1024 * 1024,

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -34,6 +34,11 @@ constants.InfoMessages = {
   EMAIL_PASSWORD_PROMPTING: 'Prompting for email and/or password'
 };
 
+constants.LogErrorMessages = {
+  INVALID_TIMESTAMP: 'timestamp invalid (ISO-8601 expected)',
+  INVALID_NONZEROINT: 'parameter invalid (non-zero integer expected)'
+};
+
 constants.JobStatus = {
   COMPLETE: 'COMPLETE'
 };

--- a/lib/error.js
+++ b/lib/error.js
@@ -51,12 +51,22 @@ const errors = {
   }
 };
 
-function KinveyError(name, message) {
+function KinveyError(name, message, debug) {
   let thisErrorMessage = null;
   if (errors[name]) thisErrorMessage = errors[name].message;
+  const errorMessage = message || thisErrorMessage;
+
   this.name = name;
-  this.message = message || thisErrorMessage;
   this.stack = (new Error).stack;
+
+  // The debug property of a Kinvey error response usually contains more explicit error detail.
+  // Use this value as the error message if supplied.
+  if (debug != null) {
+    this.message = debug;
+    return;
+  }
+
+  this.message = errorMessage;
 }
 
 KinveyError.prototype = Object.create(Error.prototype);

--- a/lib/service.js
+++ b/lib/service.js
@@ -108,8 +108,8 @@ class Service {
     return archive.finalize();
   }
 
-  logs(from, to, cb) {
-    return this._execDatalinkLogs(from, to, (err, logs) => {
+  logs(from, to, number, page, cb) {
+    return this._execDatalinkLogs(from, to, number, page, (err, logs) => {
       if (err != null) return cb(err);
       const skippedLogEntries = [];
       logs.forEach((log) => {
@@ -191,7 +191,7 @@ class Service {
     });
   }
 
-  _execDatalinkLogs(from, to, cb) {
+  _execDatalinkLogs(from, to, number, page, cb) {
     let paramAdded = false;
     let url = `/v${project.schemaVersion}/data-links/${project.service}/logs`;
     logger.debug(`Log start timestamp: ${from}`);
@@ -205,12 +205,27 @@ class Service {
         url += `&to=${to}`;
       } else {
         url += `?to=${to}`;
+        paramAdded = true;
+      }
+    }
+    if (number != null) {
+      if (paramAdded) {
+        url += `&limit=${number}`;
+      } else {
+        url += `?limit=${number}`;
+        paramAdded = true;
+      }
+    }
+    if (page != null) {
+      if (paramAdded) {
+        url += `&page=${page}`;
+      } else {
+        url += `?page=${page}`;
       }
     }
     return util.makeRequest({
       url
-    }, (err, response) => cb(err, response != null ? response.body : null)
-    );
+    }, (err, response) => cb(err, response != null ? response.body : null));
   }
 
   _execRecycle(cb) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -100,7 +100,7 @@ function makeRequest(options, cb) {
         });
       }
     }
-    if (response.body != null && response.body != null) return cb(new KinveyError(response.body.code, response.body.description, response.body.debug));
+    if (response.body != null) return cb(new KinveyError(response.body.code, response.body.description, response.body.debug));
     return cb(new KinveyError('RequestError', response.statusCode));
   });
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -100,7 +100,7 @@ function makeRequest(options, cb) {
         });
       }
     }
-    if (response.body != null && response.body != null) return cb(new KinveyError(response.body.code, response.body.description));
+    if (response.body != null && response.body != null) return cb(new KinveyError(response.body.code, response.body.description, response.body.debug));
     return cb(new KinveyError('RequestError', response.statusCode));
   });
 }

--- a/test/cmd/logs.test.js
+++ b/test/cmd/logs.test.js
@@ -80,4 +80,22 @@ describe(`./${pkg.name} logs`, () => {
       done();
     });
   });
+
+  it('should fail with an invalid \'page\' param', (done) => {
+    command.addOption('page', 'abc');
+    logs(command, (err) => {
+      expect(err).to.exist;
+      expect(err.message).to.equal('Logs \'page\' parameter invalid (non-zero integer expected)');
+      done();
+    });
+  });
+
+  it('should fail with an invalid \'number\' param', (done) => {
+    command.addOption('number', 'abc');
+    logs(command, (err) => {
+      expect(err).to.exist;
+      expect(err.message).to.equal('Logs \'number\' parameter invalid (non-zero integer expected)');
+      done();
+    });
+  });
 });

--- a/test/cmd/logs.test.js
+++ b/test/cmd/logs.test.js
@@ -20,6 +20,7 @@ const logs = require('../../cmd/logs.js');
 const pkg = require('../../package.json');
 const project = require('../../lib/project.js');
 const user = require('../../lib/user.js');
+const LogErrorMessages = require('../../lib/constants').LogErrorMessages;
 
 describe(`./${pkg.name} logs`, () => {
   const sandbox = sinon.sandbox.create();
@@ -67,7 +68,7 @@ describe(`./${pkg.name} logs`, () => {
     command.addOption('start', 'abc');
     logs(command, (err) => {
       expect(err).to.exist;
-      expect(err.message).to.equal('Logs \'start\' timestamp invalid (ISO-8601 expected)');
+      expect(err.message).to.contain(LogErrorMessages.INVALID_TIMESTAMP);
       done();
     });
   });
@@ -76,7 +77,7 @@ describe(`./${pkg.name} logs`, () => {
     command.addOption('end', 'abc');
     logs(command, (err) => {
       expect(err).to.exist;
-      expect(err.message).to.equal('Logs \'end\' timestamp invalid (ISO-8601 expected)');
+      expect(err.message).to.contain(LogErrorMessages.INVALID_TIMESTAMP);
       done();
     });
   });
@@ -85,7 +86,7 @@ describe(`./${pkg.name} logs`, () => {
     command.addOption('page', 'abc');
     logs(command, (err) => {
       expect(err).to.exist;
-      expect(err.message).to.equal('Logs \'page\' parameter invalid (non-zero integer expected)');
+      expect(err.message).to.contain(LogErrorMessages.INVALID_NONZEROINT);
       done();
     });
   });
@@ -94,7 +95,7 @@ describe(`./${pkg.name} logs`, () => {
     command.addOption('number', 'abc');
     logs(command, (err) => {
       expect(err).to.exist;
-      expect(err.message).to.equal('Logs \'number\' parameter invalid (non-zero integer expected)');
+      expect(err.message).to.contain(LogErrorMessages.INVALID_NONZEROINT);
       done();
     });
   });

--- a/test/cmd/logs.test.js
+++ b/test/cmd/logs.test.js
@@ -27,11 +27,15 @@ describe(`./${pkg.name} logs`, () => {
   before('setupStubs', () => {
     sandbox.stub(user, 'setup').callsArg(1);
     sandbox.stub(project, 'restore').callsArg(0);
-    sandbox.stub(service, 'logs').callsArg(2);
+    sandbox.stub(service, 'logs').callsArg(4);
   });
 
   afterEach('resetStubs', () => {
     sandbox.reset();
+  });
+
+  afterEach('clearOptions', () => {
+    command.clearOptions();
   });
 
   after('cleanupStubs', () => {
@@ -39,38 +43,40 @@ describe(`./${pkg.name} logs`, () => {
   });
 
   it('should setup the user.', (cb) => {
-    logs(null, null, command, (err) => {
+    logs(command, (err) => {
       expect(user.setup).to.be.calledOnce;
       cb(err);
     });
   });
 
   it('should restore the project.', (cb) => {
-    logs(null, null, command, (err) => {
+    logs(command, (err) => {
       expect(project.restore).to.be.calledOnce;
       cb(err);
     });
   });
 
   it('should retrieve log entries based on query', (cb) => {
-    logs(null, null, command, (err) => {
+    logs(command, (err) => {
       expect(service.logs).to.be.calledOnce;
       cb(err);
     });
   });
 
-  it('should fail with an invalid \'from\' timestamp', (done) => {
-    logs('abc', null, command, (err) => {
+  it('should fail with an invalid \'start\' timestamp', (done) => {
+    command.addOption('start', 'abc');
+    logs(command, (err) => {
       expect(err).to.exist;
-      expect(err.message).to.equal("Logs \'from\' timestamp invalid (ISO-8601 required)");
+      expect(err.message).to.equal('Logs \'start\' timestamp invalid (ISO-8601 expected)');
       done();
     });
   });
 
-  it('should fail with an invalid \'to\' timestamp', (done) => {
-    logs(null, 'abc', command, (err) => {
+  it('should fail with an invalid \'end\' timestamp', (done) => {
+    command.addOption('end', 'abc');
+    logs(command, (err) => {
       expect(err).to.exist;
-      expect(err.message).to.equal("Logs \'to\' timestamp invalid (ISO-8601 required)");
+      expect(err.message).to.equal('Logs \'end\' timestamp invalid (ISO-8601 expected)');
       done();
     });
   });

--- a/test/fixtures/command.js
+++ b/test/fixtures/command.js
@@ -13,13 +13,25 @@
  * contents is a violation of applicable laws.
  */
 
-function noop() {
-  return {};
+let options = {};
+
+function addOption(key, value) {
+  options[key] = value;
+}
+
+function clearOptions() {
+  options = {};
+}
+
+function opts() {
+  return options;
 }
 
 module.exports = {
-  opts: noop,
+  addOption,
+  clearOptions,
+  opts,
   parent: {
-    opts: noop
+    opts: () => {}
   }
 };

--- a/test/lib/service.test.js
+++ b/test/lib/service.test.js
@@ -207,13 +207,15 @@ describe('service', () => {
     });
   });
 
-  describe('logs', () => {
+  describe.only('logs', () => {
     beforeEach('configure', () => {
       project.app = project.service = '123';
       this.message = uuid.v4();
       this.containerId = uuid.v4();
       this.from = uuid.v4();
       this.to = uuid.v4();
+      this.page = Math.floor(Math.random() * 10) + 1;
+      this.limit = Math.floor(Math.random() * 10) + 1;
     });
     afterEach('configure', () => {
       project.app = project.service = null;
@@ -252,7 +254,7 @@ describe('service', () => {
           });
         });
       });
-      describe('with a logs \'to\' filter', () => {
+      describe('with a logs \'from\' filter', () => {
         beforeEach('api', () => {
           this.mock = api.get(`/v${project.schemaVersion}/data-links/${project.service}/logs?from=${this.from}`).reply(200, [
             {
@@ -320,6 +322,106 @@ describe('service', () => {
 
         it('should the service logs.', (cb) => {
           service.logs(this.from, this.to, null, null, (err, logs) => {
+            expect(logs[0].threshold).to.equal('info');
+            expect(logs[0].message).to.equal(this.message);
+            expect(logs[0].containerId).to.equal(this.containerId);
+            cb(err);
+          });
+        });
+      });
+      describe('with a logs \'page\' filter', () => {
+        beforeEach('api', () => {
+          this.mock = api.get(`/v${project.schemaVersion}/data-links/${project.service}/logs?page=${this.page}`).reply(200, [
+            {
+              threshold: 'info',
+              message: this.message,
+              timestamp: new Date().toISOString(),
+              containerId: this.containerId
+            }
+          ]);
+        });
+        afterEach('api', () => {
+          this.mock.done();
+          delete this.mock;
+        });
+
+        it('should retrieve the service logs.', (cb) => {
+          service.logs(null, null, null, this.page, (err, logs) => {
+            expect(logs[0].threshold).to.equal('info');
+            expect(logs[0].message).to.equal(this.message);
+            expect(logs[0].containerId).to.equal(this.containerId);
+            cb(err);
+          });
+        });
+      });
+      describe('with a logs \'number\' filter', () => {
+        beforeEach('api', () => {
+          this.mock = api.get(`/v${project.schemaVersion}/data-links/${project.service}/logs?limit=${this.limit}`).reply(200, [
+            {
+              threshold: 'info',
+              message: this.message,
+              timestamp: new Date().toISOString(),
+              containerId: this.containerId
+            }
+          ]);
+        });
+        afterEach('api', () => {
+          this.mock.done();
+          delete this.mock;
+        });
+
+        it('should retrieve the service logs.', (cb) => {
+          service.logs(null, null, this.limit, null, (err, logs) => {
+            expect(logs[0].threshold).to.equal('info');
+            expect(logs[0].message).to.equal(this.message);
+            expect(logs[0].containerId).to.equal(this.containerId);
+            cb(err);
+          });
+        });
+      });
+      describe('with logs \'number\' and \'page\' filters', () => {
+        beforeEach('api', () => {
+          this.mock = api.get(`/v${project.schemaVersion}/data-links/${project.service}/logs?limit=${this.limit}&page=${this.page}`).reply(200, [
+            {
+              threshold: 'info',
+              message: this.message,
+              timestamp: new Date().toISOString(),
+              containerId: this.containerId
+            }
+          ]);
+        });
+        afterEach('api', () => {
+          this.mock.done();
+          delete this.mock;
+        });
+
+        it('should retrieve the service logs.', (cb) => {
+          service.logs(null, null, this.limit, this.page, (err, logs) => {
+            expect(logs[0].threshold).to.equal('info');
+            expect(logs[0].message).to.equal(this.message);
+            expect(logs[0].containerId).to.equal(this.containerId);
+            cb(err);
+          });
+        });
+      });
+      describe('with all filters', () => {
+        beforeEach('api', () => {
+          this.mock = api.get(`/v${project.schemaVersion}/data-links/${project.service}/logs?from=${this.from}&to=${this.to}&limit=${this.limit}&page=${this.page}`).reply(200, [
+            {
+              threshold: 'info',
+              message: this.message,
+              timestamp: new Date().toISOString(),
+              containerId: this.containerId
+            }
+          ]);
+        });
+        afterEach('api', () => {
+          this.mock.done();
+          delete this.mock;
+        });
+
+        it('should retrieve the service logs.', (cb) => {
+          service.logs(this.from, this.to, this.limit, this.page, (err, logs) => {
             expect(logs[0].threshold).to.equal('info');
             expect(logs[0].message).to.equal(this.message);
             expect(logs[0].containerId).to.equal(this.containerId);

--- a/test/lib/service.test.js
+++ b/test/lib/service.test.js
@@ -207,7 +207,7 @@ describe('service', () => {
     });
   });
 
-  describe.only('logs', () => {
+  describe('logs', () => {
     beforeEach('configure', () => {
       project.app = project.service = '123';
       this.message = uuid.v4();

--- a/test/lib/service.test.js
+++ b/test/lib/service.test.js
@@ -244,7 +244,7 @@ describe('service', () => {
         });
 
         it('should the service logs.', (cb) => {
-          service.logs(null, null, (err, logs) => {
+          service.logs(null, null, null, null, (err, logs) => {
             expect(logs[0].threshold).to.equal('info');
             expect(logs[0].message).to.equal(this.message);
             expect(logs[0].containerId).to.equal(this.containerId);
@@ -269,7 +269,7 @@ describe('service', () => {
         });
 
         it('should the service logs.', (cb) => {
-          service.logs(this.from, null, (err, logs) => {
+          service.logs(this.from, null, null, null, (err, logs) => {
             expect(logs[0].threshold).to.equal('info');
             expect(logs[0].message).to.equal(this.message);
             expect(logs[0].containerId).to.equal(this.containerId);
@@ -294,7 +294,7 @@ describe('service', () => {
         });
 
         it('should the service logs.', (cb) => {
-          service.logs(null, this.to, (err, logs) => {
+          service.logs(null, this.to, null, null, (err, logs) => {
             expect(logs[0].threshold).to.equal('info');
             expect(logs[0].message).to.equal(this.message);
             expect(logs[0].containerId).to.equal(this.containerId);
@@ -319,7 +319,7 @@ describe('service', () => {
         });
 
         it('should the service logs.', (cb) => {
-          service.logs(this.from, this.to, (err, logs) => {
+          service.logs(this.from, this.to, null, null, (err, logs) => {
             expect(logs[0].threshold).to.equal('info');
             expect(logs[0].message).to.equal(this.message);
             expect(logs[0].containerId).to.equal(this.containerId);
@@ -354,7 +354,7 @@ describe('service', () => {
         });
 
         it('should not any logs.', (cb) => {
-          service.logs(null, null, (err, logs) => {
+          service.logs(null, null, null, null, (err, logs) => {
             expect(logs[0].threshold).to.equal('info');
             expect(logs[0].message).not.to.exist;
             expect(logs[0].containerId).to.equal(this.containerId);
@@ -381,7 +381,7 @@ describe('service', () => {
 
         it('should a stringified message.', (cb) => {
           const inspect = stdout.inspect();
-          service.logs(null, null, (err, logs) => {
+          service.logs(null, null, null, null, (err, logs) => {
             inspect.restore();
             const stdoutResult = inspect.output;
             expect(stdoutResult[0]).to.contain(this.message);


### PR DESCRIPTION
- Adds `--start` and `--end` flags (which replace) `kinvey logs [from] [to]` optional method params
- Adds `--number`/`-n` option for specifying number of entries to return (default = 100, max = 2500)
- Adds `--page` option for viewing logs in pages (of size `-n`)

... plus tests