### PR TITLE
BACK-2804: Error out if deprecated 'from' and/or 'to' params are provided to 'logs' cmd

### DIFF
--- a/cmd/config.js
+++ b/cmd/config.js
@@ -43,5 +43,5 @@ module.exports = configure;
 
 program
   .command('config [instance]')
-  .description("set project options (including optional Kinvey instance, i.e. 'acme-us1)")
+  .description("set project options (including optional Kinvey instance, e.g. 'acme-us1')")
   .action(configure);

--- a/cmd/logs.js
+++ b/cmd/logs.js
@@ -36,7 +36,7 @@ function isValidNonZeroInteger(number) {
   return /^\d+$/.test(number);
 }
 
-function logs(command, cb) {
+function logs(from, to, command, cb) {
   const options = init(command);
 
   // Validate input parameters
@@ -56,7 +56,12 @@ function logs(command, cb) {
   return async.series([
     (next) => user.setup(options, next),
     (next) => project.restore(next),
-    (next) => service.logs(options.start, options.end, options.number, options.page, next)
+    (next) => service.logs(options.start, options.end, options.number, options.page, next),
+    (next) => {
+      if (from != null) logger.warn('Logs \'from\' param is deprecated. Please use the \'--start\' flag instead');
+      if (to != null) logger.warn('Logs \'to\' param is deprecated. Please use the \'--end\' flag instead');
+      next();
+    }
   ], (err) => {
     handleActionFailure(err, cb);
   });

--- a/cmd/logs.js
+++ b/cmd/logs.js
@@ -38,12 +38,12 @@ function isValidNonZeroInteger(number) {
   return /^\d+$/.test(number);
 }
 
-function logs(from, to, command, cb) {
+function logs(argsArray, command, cb) {
   const options = init(command);
 
   // Handle deprecated logs command params
-  if (from != null || to != null) {
-    return handleActionFailure(new KinveyError('DeprecationError', `Logs ${chalk.whiteBright('[from]')} and ${chalk.whiteBright('[to]')} parameters have been removed. Use ${chalk.blueBright('--from')} and ${chalk.blueBright('--to')} flags instead`), cb);
+  if (argsArray != null && argsArray.length > 0) {
+    return handleActionFailure(new KinveyError('DeprecationError', `Version 1.x ${chalk.whiteBright('[from]')} and ${chalk.whiteBright('[to]')} params have been converted to options. Use ${chalk.blueBright('--from')} and ${chalk.blueBright('--to')} to filter by timestamp instead.`), cb);
   }
 
   // Validate input parameters
@@ -69,10 +69,13 @@ function logs(from, to, command, cb) {
 module.exports = logs;
 
 program
-  .command('logs')
-  .option('--start <string>', 'fetch log entries starting from provided timestamp')
-  .option('--end <string>', 'fetch log entries up to provided timestamp')
+  .command('logs [params...]')
+  .option('--from <string>', 'fetch log entries starting from provided timestamp')
+  .option('--to <string>', 'fetch log entries up to provided timestamp')
   .option('--page <number>', 'page (non-zero integer, default=1)')
   .option('-n, --number <number>', `number of entries to fetch, i.e. page size (non-zero integer, default=${config.logFetchDefault}, max=${config.logFetchLimit})`)
   .description('retrieve and display Internal Flex Service logs')
-  .action(logs);
+  .action(logs)
+    .on('--help', () => {
+      console.log('    Note:  Version 1.x [from] and [to] params have been converted to options. Use \'--from\' and \'--to\' to filter by timestamp instead.\n');
+    });

--- a/config/default.js
+++ b/config/default.js
@@ -19,7 +19,7 @@ const osHomedir = require('os-homedir');
 module.exports = {
   host: 'https://manage.kinvey.com/',
   logFetchDefault: 100,
-  logFetchLimit: 2500,
+  logFetchLimit: 2000,
   defaultSchemaVersion: 2,
   artifacts: ['.git', '.svn', 'node_modules', 'output.log'],
   maxUploadSize: 10 * 1024 * 1024,

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -35,8 +35,8 @@ constants.InfoMessages = {
 };
 
 constants.LogErrorMessages = {
-  INVALID_TIMESTAMP: 'timestamp invalid (ISO-8601 expected)',
-  INVALID_NONZEROINT: 'parameter invalid (non-zero integer expected)'
+  INVALID_TIMESTAMP: 'invalid (ISO-8601 timestamp expected)',
+  INVALID_NONZEROINT: 'invalid (non-zero integer expected)'
 };
 
 constants.JobStatus = {

--- a/test/cmd/logs.test.js
+++ b/test/cmd/logs.test.js
@@ -65,7 +65,7 @@ describe(`./${pkg.name} logs`, () => {
   });
 
   it('should fail with an invalid \'start\' timestamp', (done) => {
-    command.addOption('start', 'abc');
+    command.addOption('from', 'abc');
     logs(null, null, command, (err) => {
       expect(err).to.exist;
       expect(err.message).to.contain(LogErrorMessages.INVALID_TIMESTAMP);
@@ -74,7 +74,7 @@ describe(`./${pkg.name} logs`, () => {
   });
 
   it('should fail with an invalid \'end\' timestamp', (done) => {
-    command.addOption('end', 'abc');
+    command.addOption('to', 'abc');
     logs(null, null, command, (err) => {
       expect(err).to.exist;
       expect(err.message).to.contain(LogErrorMessages.INVALID_TIMESTAMP);
@@ -100,10 +100,10 @@ describe(`./${pkg.name} logs`, () => {
     });
   });
 
-  it('should succeed with deprecated params included', (done) => {
+  it('should fail with deprecated params included', (done) => {
     logs('abc', 'def', command, (err) => {
-      expect(err).not.to.exist;
-      expect(service.logs).to.be.calledOnce;
+      expect(err).to.exist;
+      expect(err.message).to.contain('parameters have been removed.');
       done();
     });
   });

--- a/test/cmd/logs.test.js
+++ b/test/cmd/logs.test.js
@@ -44,21 +44,21 @@ describe(`./${pkg.name} logs`, () => {
   });
 
   it('should setup the user.', (cb) => {
-    logs(command, (err) => {
+    logs(null, null, command, (err) => {
       expect(user.setup).to.be.calledOnce;
       cb(err);
     });
   });
 
   it('should restore the project.', (cb) => {
-    logs(command, (err) => {
+    logs(null, null, command, (err) => {
       expect(project.restore).to.be.calledOnce;
       cb(err);
     });
   });
 
   it('should retrieve log entries based on query', (cb) => {
-    logs(command, (err) => {
+    logs(null, null, command, (err) => {
       expect(service.logs).to.be.calledOnce;
       cb(err);
     });
@@ -66,7 +66,7 @@ describe(`./${pkg.name} logs`, () => {
 
   it('should fail with an invalid \'start\' timestamp', (done) => {
     command.addOption('start', 'abc');
-    logs(command, (err) => {
+    logs(null, null, command, (err) => {
       expect(err).to.exist;
       expect(err.message).to.contain(LogErrorMessages.INVALID_TIMESTAMP);
       done();
@@ -75,27 +75,35 @@ describe(`./${pkg.name} logs`, () => {
 
   it('should fail with an invalid \'end\' timestamp', (done) => {
     command.addOption('end', 'abc');
-    logs(command, (err) => {
+    logs(null, null, command, (err) => {
       expect(err).to.exist;
       expect(err.message).to.contain(LogErrorMessages.INVALID_TIMESTAMP);
       done();
     });
   });
 
-  it('should fail with an invalid \'page\' param', (done) => {
+  it('should fail with an invalid \'page\' flag', (done) => {
     command.addOption('page', 'abc');
-    logs(command, (err) => {
+    logs(null, null, command, (err) => {
       expect(err).to.exist;
       expect(err.message).to.contain(LogErrorMessages.INVALID_NONZEROINT);
       done();
     });
   });
 
-  it('should fail with an invalid \'number\' param', (done) => {
+  it('should fail with an invalid \'number\' flag', (done) => {
     command.addOption('number', 'abc');
-    logs(command, (err) => {
+    logs(null, null, command, (err) => {
       expect(err).to.exist;
       expect(err.message).to.contain(LogErrorMessages.INVALID_NONZEROINT);
+      done();
+    });
+  });
+
+  it('should succeed with deprecated params included \'number\' flag', (done) => {
+    logs('abc', 'def', command, (err) => {
+      expect(err).not.to.exist;
+      expect(service.logs).to.be.calledOnce;
       done();
     });
   });

--- a/test/cmd/logs.test.js
+++ b/test/cmd/logs.test.js
@@ -64,7 +64,7 @@ describe(`./${pkg.name} logs`, () => {
     });
   });
 
-  it('should fail with an invalid \'start\' timestamp', (done) => {
+  it('should fail with an invalid \'from\' timestamp', (done) => {
     command.addOption('from', 'abc');
     logs(null, command, (err) => {
       expect(err).to.exist;
@@ -73,7 +73,7 @@ describe(`./${pkg.name} logs`, () => {
     });
   });
 
-  it('should fail with an invalid \'end\' timestamp', (done) => {
+  it('should fail with an invalid \'to\' timestamp', (done) => {
     command.addOption('to', 'abc');
     logs(null, command, (err) => {
       expect(err).to.exist;

--- a/test/cmd/logs.test.js
+++ b/test/cmd/logs.test.js
@@ -100,7 +100,7 @@ describe(`./${pkg.name} logs`, () => {
     });
   });
 
-  it('should succeed with deprecated params included \'number\' flag', (done) => {
+  it('should succeed with deprecated params included', (done) => {
     logs('abc', 'def', command, (err) => {
       expect(err).not.to.exist;
       expect(service.logs).to.be.calledOnce;

--- a/test/cmd/logs.test.js
+++ b/test/cmd/logs.test.js
@@ -44,21 +44,21 @@ describe(`./${pkg.name} logs`, () => {
   });
 
   it('should setup the user.', (cb) => {
-    logs(null, null, command, (err) => {
+    logs(null, command, (err) => {
       expect(user.setup).to.be.calledOnce;
       cb(err);
     });
   });
 
   it('should restore the project.', (cb) => {
-    logs(null, null, command, (err) => {
+    logs(null, command, (err) => {
       expect(project.restore).to.be.calledOnce;
       cb(err);
     });
   });
 
   it('should retrieve log entries based on query', (cb) => {
-    logs(null, null, command, (err) => {
+    logs(null, command, (err) => {
       expect(service.logs).to.be.calledOnce;
       cb(err);
     });
@@ -66,7 +66,7 @@ describe(`./${pkg.name} logs`, () => {
 
   it('should fail with an invalid \'start\' timestamp', (done) => {
     command.addOption('from', 'abc');
-    logs(null, null, command, (err) => {
+    logs(null, command, (err) => {
       expect(err).to.exist;
       expect(err.message).to.contain(LogErrorMessages.INVALID_TIMESTAMP);
       done();
@@ -75,7 +75,7 @@ describe(`./${pkg.name} logs`, () => {
 
   it('should fail with an invalid \'end\' timestamp', (done) => {
     command.addOption('to', 'abc');
-    logs(null, null, command, (err) => {
+    logs(null, command, (err) => {
       expect(err).to.exist;
       expect(err.message).to.contain(LogErrorMessages.INVALID_TIMESTAMP);
       done();
@@ -84,7 +84,7 @@ describe(`./${pkg.name} logs`, () => {
 
   it('should fail with an invalid \'page\' flag', (done) => {
     command.addOption('page', 'abc');
-    logs(null, null, command, (err) => {
+    logs(null, command, (err) => {
       expect(err).to.exist;
       expect(err.message).to.contain(LogErrorMessages.INVALID_NONZEROINT);
       done();
@@ -93,7 +93,7 @@ describe(`./${pkg.name} logs`, () => {
 
   it('should fail with an invalid \'number\' flag', (done) => {
     command.addOption('number', 'abc');
-    logs(null, null, command, (err) => {
+    logs(null, command, (err) => {
       expect(err).to.exist;
       expect(err.message).to.contain(LogErrorMessages.INVALID_NONZEROINT);
       done();
@@ -101,9 +101,9 @@ describe(`./${pkg.name} logs`, () => {
   });
 
   it('should fail with deprecated params included', (done) => {
-    logs('abc', 'def', command, (err) => {
+    logs(['abc', 'def'], command, (err) => {
       expect(err).to.exist;
-      expect(err.message).to.contain('parameters have been removed.');
+      expect(err.message).to.contain('params have been converted to options');
       done();
     });
   });


### PR DESCRIPTION
This branch gracefully handles the deprecation of `[from] [to]` parameters (as part of the transition to `--from --to` flags in version 2.0).
* Added `from` and `to` args back to the `logs` command function to prevent the CLI from crashing if legacy users try to filter logs using the deprecated parameters
* CLI throws an error instructing users to use the new command format when either deprecated param is used
* Added tests