### PR TITLE
BACK-2580: Convert status 'deployedAt' param to 'requestedAt' 

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -187,10 +187,10 @@ class Service {
         }
       }
 
-      if (response.body.deployedAt != null && response.body.deployUserInfo != null) {
+      if (response.body.requestedAt != null && response.body.deployUserInfo != null) {
         process.stdout.write('\n');
-        console.log(`  Deployed on:   ${new Date(response.body.deployedAt)}`);
-        process.stdout.write(`  Deployed by:   ${response.body.deployUserInfo.email}`);
+        console.log(`  Requested on:   ${new Date(response.body.requestedAt)}`);
+        process.stdout.write(`  Requested by:   ${response.body.deployUserInfo.email}`);
 
         if (response.body.deployUserInfo.firstName != null && response.body.deployUserInfo.lastName != null) {
           process.stdout.write(` (${response.body.deployUserInfo.firstName} ${response.body.deployUserInfo.lastName})`);
@@ -206,7 +206,7 @@ class Service {
 
       process.stdout.write('\n');
 
-      return cb(null, { status: response.body.status, version: response.body.version, deployedAt: response.body.deployedAt, deployUserInfo: response.body.deployUserInfo });
+      return cb(null, { status: response.body.status, version: response.body.version, requestedAt: response.body.requestedAt, deployUserInfo: response.body.deployUserInfo });
     });
   }
 

--- a/test/unit/lib/service.test.js
+++ b/test/unit/lib/service.test.js
@@ -227,14 +227,14 @@ describe('service', () => {
 
     it('should retrieve the service status, version, deploy time, and deployer email address.', (cb) => {
       sandbox.restore();
-      const deployedAt = new Date().toISOString();
+      const requestedAt = new Date().toISOString();
       const testEmailAddress = uuid.v4();
       sandbox.stub(util, 'makeRequest')
         .withArgs({ url: `/v${project.schemaVersion}/data-links/${project.service}/status` })
         .callsArgWith(1, null, { body: {
           status: ServiceStatus.ONLINE,
           version: '0.0.1',
-          deployedAt,
+          requestedAt,
           deployUserInfo: {
             email: testEmailAddress
           }
@@ -243,7 +243,7 @@ describe('service', () => {
       service.serviceStatus((err, result) => {
         expect(result.status).to.equal(ServiceStatus.ONLINE);
         expect(result.version).to.equal('0.0.1');
-        expect(result.deployedAt).to.equal(deployedAt);
+        expect(result.requestedAt).to.equal(requestedAt);
         expect(result.deployUserInfo.email).to.equal(testEmailAddress);
         cb(err);
       });
@@ -251,7 +251,7 @@ describe('service', () => {
 
     it('should retrieve the service status, version, deploy time, deployer email address, and deployer first/last name.', (cb) => {
       sandbox.restore();
-      const deployedAt = new Date().toISOString();
+      const requestedAt = new Date().toISOString();
       const testEmailAddress = uuid.v4();
       const testFirstName = uuid.v4();
       const testLastName = uuid.v4();
@@ -261,7 +261,7 @@ describe('service', () => {
           body: {
             status: ServiceStatus.ONLINE,
             version: '0.0.1',
-            deployedAt,
+            requestedAt,
             deployUserInfo: {
               email: testEmailAddress,
               firstName: testFirstName,
@@ -273,7 +273,7 @@ describe('service', () => {
       service.serviceStatus((err, result) => {
         expect(result.status).to.equal(ServiceStatus.ONLINE);
         expect(result.version).to.equal('0.0.1');
-        expect(result.deployedAt).to.equal(deployedAt);
+        expect(result.requestedAt).to.equal(requestedAt);
         expect(result.deployUserInfo.email).to.equal(testEmailAddress);
         expect(result.deployUserInfo.firstName).to.equal(testFirstName);
         expect(result.deployUserInfo.lastName).to.equal(testLastName);


### PR DESCRIPTION
This conversion is necessary due to an uptime change. Backwards-compatibility is ensured as no components consuming `deployedAt` have been publicly deployed or released at the time of the creation of this pull request.