### PR TITLE
Confirm some delete operations; flex create, flex delete

### DIFF
--- a/__snapshots__/coll-delete.test.js
+++ b/__snapshots__/coll-delete.test.js
@@ -41,6 +41,7 @@ Options:
   -h, --help                Show help                                  [boolean]
   --env                     Env ID/name                                 [string]
   --app                     App ID/name                                 [string]
+  --no-prompt               Do not prompt             [boolean] [default: false]
 
 Not enough non-option arguments: got 0, need at least 1
 
@@ -203,6 +204,7 @@ Options:
   -h, --help                Show help                                  [boolean]
   --env                     Env ID/name                                 [string]
   --app                     App ID/name                                 [string]
+  --no-prompt               Do not prompt             [boolean] [default: false]
 
 Application is required. Please set active app or use the --app option.
 
@@ -233,6 +235,7 @@ Options:
   -h, --help                Show help                                  [boolean]
   --env                     Env ID/name                                 [string]
   --app                     App ID/name                                 [string]
+  --no-prompt               Do not prompt             [boolean] [default: false]
 
 Application is required. Please set active app or use the --app option.
 

--- a/__snapshots__/env-delete.test.js
+++ b/__snapshots__/env-delete.test.js
@@ -1,23 +1,3 @@
-exports['env delete without profile with credentials as options, existent app and env should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Logging in user: janeDoe@mail.com
-[debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 200
-[debug] Using application: TestApp
-[debug] Request:  GET http://localhost:3234/v2/apps
-[debug] Response: GET http://localhost:3234/v2/apps 200
-[debug] Using environment: Development
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M
-[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M 204
-[debug] Request:  DELETE http://localhost:3234/session
-[debug] Response: DELETE http://localhost:3234/session 204
-[debug] Logged out current user.
-Deleted environment: kid_Sy4yRNV_M
-
-`
-
 exports['env delete with profile when active app is set active env is set without env arg should succeed 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
@@ -188,6 +168,7 @@ Options:
   --no-color                Disable colors                             [boolean]
   -h, --help                Show help                                  [boolean]
   --app                     App ID/name                                 [string]
+  --no-prompt               Do not prompt             [boolean] [default: false]
 
 Application is required. Please set active app or use the --app option.
 
@@ -217,7 +198,28 @@ Options:
   --no-color                Disable colors                             [boolean]
   -h, --help                Show help                                  [boolean]
   --app                     App ID/name                                 [string]
+  --no-prompt               Do not prompt             [boolean] [default: false]
 
 Application is required. Please set active app or use the --app option.
+
+`
+
+exports['env delete without profile with credentials as options, existent app and env should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Logging in user: janeDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 200
+[debug] Using application: TestApp
+[debug] Request:  GET http://localhost:3234/v2/apps
+[debug] Response: GET http://localhost:3234/v2/apps 200
+[debug] Using environment: Development
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M
+[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M 204
+[debug] Request:  DELETE http://localhost:3234/session
+[debug] Response: DELETE http://localhost:3234/session 204
+[debug] Logged out current user.
+Deleted environment: kid_Sy4yRNV_M
 
 `

--- a/__snapshots__/flex-clear.test.js
+++ b/__snapshots__/flex-clear.test.js
@@ -1,0 +1,45 @@
+exports['flex clear when project is not set should succeed and output default format 1'] = `
+[debug] Checking for package updates
+[debug] Writing contents to file projectSetupPath
+Project data cleared. Run kinvey flex init to get started.
+
+`
+
+exports['flex clear when project is not set should succeed and output JSON 1'] = `
+[debug] Checking for package updates
+[debug] Writing contents to file projectSetupPath
+{
+  "result": null
+}
+
+`
+
+exports['flex clear when project is set should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Writing contents to file projectSetupPath
+Project data cleared. Run kinvey flex init to get started.
+
+`
+
+exports['flex clear when project is set with too many args should fail 1'] = `
+kinvey flex clear
+
+Clear project settings
+
+Options:
+  --version                 Show version number                        [boolean]
+  --email                   E-mail address of your Kinvey account       [string]
+  --password                Password of your Kinvey account             [string]
+  --2fa, --2Fa              Two-factor authentication token             [string]
+  --instanceId              Instance ID                                 [string]
+  --profile                 Profile to use                              [string]
+  --output                  Output format             [string] [choices: "json"]
+  --silent                  Do not output anything                     [boolean]
+  --suppress-version-check  Do not check for package updates           [boolean]
+  --verbose                 Output debug messages                      [boolean]
+  --no-color                Disable colors                             [boolean]
+  -h, --help                Show help                                  [boolean]
+
+Too many non-option arguments: got 1, maximum of 0
+
+`

--- a/__snapshots__/flex-create.test.js
+++ b/__snapshots__/flex-create.test.js
@@ -1,0 +1,129 @@
+exports['flex create with active profile with a name, secret and app should succeed and output default format 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
+[debug] Request:  POST http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/data-links
+[debug] Response: POST http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/data-links 201
+Created service: 12378kdl2
+
+`
+
+exports['flex create with active profile with a name, secret and app should succeed and output JSON 1'] = `
+{
+  "result": {
+    "id": "12378kdl2"
+  }
+}
+
+`
+
+exports['flex create with active profile without a name should fail 1'] = `
+kinvey flex create <name>
+
+Create a Flex service
+
+Positionals:
+  name  Flex service name                                             [required]
+
+Options:
+  --version                 Show version number                        [boolean]
+  --email                   E-mail address of your Kinvey account       [string]
+  --password                Password of your Kinvey account             [string]
+  --2fa, --2Fa              Two-factor authentication token             [string]
+  --instanceId              Instance ID                                 [string]
+  --profile                 Profile to use                              [string]
+  --output                  Output format             [string] [choices: "json"]
+  --silent                  Do not output anything                     [boolean]
+  --suppress-version-check  Do not check for package updates           [boolean]
+  --verbose                 Output debug messages                      [boolean]
+  --no-color                Disable colors                             [boolean]
+  -h, --help                Show help                                  [boolean]
+  --app                     App ID/name                                 [string]
+  --org                     Org ID/name                                 [string]
+  --secret                  Shared secret                    [string] [required]
+
+Not enough non-option arguments: got 0, need at least 1
+
+`
+
+exports['flex create with active profile without a secret should fail 1'] = `
+kinvey flex create <name>
+
+Create a Flex service
+
+Positionals:
+  name  Flex service name                                             [required]
+
+Options:
+  --version                 Show version number                        [boolean]
+  --email                   E-mail address of your Kinvey account       [string]
+  --password                Password of your Kinvey account             [string]
+  --2fa, --2Fa              Two-factor authentication token             [string]
+  --instanceId              Instance ID                                 [string]
+  --profile                 Profile to use                              [string]
+  --output                  Output format             [string] [choices: "json"]
+  --silent                  Do not output anything                     [boolean]
+  --suppress-version-check  Do not check for package updates           [boolean]
+  --verbose                 Output debug messages                      [boolean]
+  --no-color                Disable colors                             [boolean]
+  -h, --help                Show help                                  [boolean]
+  --app                     App ID/name                                 [string]
+  --org                     Org ID/name                                 [string]
+  --secret                  Shared secret                    [string] [required]
+
+Missing required argument: secret
+
+`
+
+exports['flex create with active profile without an app and org should fail 1'] = `
+[error] Error: Either '--app' or '--org' option must be set.
+
+`
+
+exports['flex create with active profile with both app and org should fail 1'] = `
+kinvey flex create <name>
+
+Create a Flex service
+
+Positionals:
+  name  Flex service name                                             [required]
+
+Options:
+  --version                 Show version number                        [boolean]
+  --email                   E-mail address of your Kinvey account       [string]
+  --password                Password of your Kinvey account             [string]
+  --2fa, --2Fa              Two-factor authentication token             [string]
+  --instanceId              Instance ID                                 [string]
+  --profile                 Profile to use                              [string]
+  --output                  Output format             [string] [choices: "json"]
+  --silent                  Do not output anything                     [boolean]
+  --suppress-version-check  Do not check for package updates           [boolean]
+  --verbose                 Output debug messages                      [boolean]
+  --no-color                Disable colors                             [boolean]
+  -h, --help                Show help                                  [boolean]
+  --app                     App ID/name                                 [string]
+  --org                     Org ID/name                                 [string]
+  --secret                  Shared secret                    [string] [required]
+
+Arguments app and org are mutually exclusive
+
+`
+
+exports['flex create with one-time session with name, secret and org should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Logging in user: janeDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 200
+[debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
+[debug] Request:  GET http://localhost:3234/v2/organizations/f71b0d5e60684b48b8265e7fa50302b9
+[debug] Response: GET http://localhost:3234/v2/organizations/f71b0d5e60684b48b8265e7fa50302b9 200
+[debug] Request:  POST http://localhost:3234/v2/organizations/f71b0d5e60684b48b8265e7fa50302b9/data-links
+[debug] Response: POST http://localhost:3234/v2/organizations/f71b0d5e60684b48b8265e7fa50302b9/data-links 201
+[debug] Request:  DELETE http://localhost:3234/session
+[debug] Response: DELETE http://localhost:3234/session 204
+[debug] Logged out current user.
+Created service: 12378kdl2
+
+`

--- a/__snapshots__/flex-create.test.js
+++ b/__snapshots__/flex-create.test.js
@@ -6,14 +6,15 @@ exports['flex create with active profile with a name, secret and app should succ
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
 [debug] Request:  POST http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/data-links
 [debug] Response: POST http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/data-links 201
-Created service: 12378kdl2
+Created service: 12378kdl2. Secret: 789
 
 `
 
 exports['flex create with active profile with a name, secret and app should succeed and output JSON 1'] = `
 {
   "result": {
-    "id": "12378kdl2"
+    "id": "12378kdl2",
+    "secret": "789"
   }
 }
 
@@ -42,38 +43,9 @@ Options:
   -h, --help                Show help                                  [boolean]
   --app                     App ID/name                                 [string]
   --org                     Org ID/name                                 [string]
-  --secret                  Shared secret                    [string] [required]
+  --secret                  Shared secret                               [string]
 
 Not enough non-option arguments: got 0, need at least 1
-
-`
-
-exports['flex create with active profile without a secret should fail 1'] = `
-kinvey flex create <name>
-
-Create a Flex service
-
-Positionals:
-  name  Flex service name                                             [required]
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instanceId              Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --app                     App ID/name                                 [string]
-  --org                     Org ID/name                                 [string]
-  --secret                  Shared secret                    [string] [required]
-
-Missing required argument: secret
 
 `
 
@@ -105,7 +77,7 @@ Options:
   -h, --help                Show help                                  [boolean]
   --app                     App ID/name                                 [string]
   --org                     Org ID/name                                 [string]
-  --secret                  Shared secret                    [string] [required]
+  --secret                  Shared secret                               [string]
 
 Arguments app and org are mutually exclusive
 
@@ -124,6 +96,11 @@ exports['flex create with one-time session with name, secret and org should succ
 [debug] Request:  DELETE http://localhost:3234/session
 [debug] Response: DELETE http://localhost:3234/session 204
 [debug] Logged out current user.
-Created service: 12378kdl2
+Created service: 12378kdl2. Secret: 789
+
+`
+
+exports['flex create with active profile without a secret should succeed 1'] = `
+Created service: 12378kdl2. Secret: 789
 
 `

--- a/__snapshots__/flex-delete.test.js
+++ b/__snapshots__/flex-delete.test.js
@@ -1,45 +1,70 @@
-exports['flex delete when project is not set should succeed and output default format 1'] = `
+exports['flex delete when active profile is set and project config is set without explicit profile and serviceId should succeed 1'] = `
 [debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2
+[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2 200
+[debug] Request:  DELETE http://localhost:3234/v2/data-links/12378kdl2
+[debug] Response: DELETE http://localhost:3234/v2/data-links/12378kdl2 204
 [debug] Writing contents to file projectSetupPath
-Project data cleared. Run kinvey flex init to get started.
+[debug] Deleted service from project settings.
+Deleted service: 12378kdl2
 
 `
 
-exports['flex delete when project is not set should succeed and output JSON 1'] = `
+exports['flex delete when active profile is set and project config is set with explicit profile and without serviceId should succeed 1'] = `
 [debug] Checking for package updates
+[debug] Using profile 'nonActiveProfile'
+[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2
+[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2 200
+[debug] Request:  DELETE http://localhost:3234/v2/data-links/12378kdl2
+[debug] Response: DELETE http://localhost:3234/v2/data-links/12378kdl2 204
 [debug] Writing contents to file projectSetupPath
+[debug] Deleted service from project settings.
 {
-  "result": null
+  "result": {
+    "id": "12378kdl2"
+  }
 }
 
 `
 
-exports['flex delete when project is set should succeed 1'] = `
+exports['flex delete when active profile is set and project config is set without explicit profile and with non-existent serviceId should fail 1'] = `
 [debug] Checking for package updates
-[debug] Writing contents to file projectSetupPath
-Project data cleared. Run kinvey flex init to get started.
+[debug] Using profile 'activeProfile'
+[debug] Request:  GET http://localhost:3234/v2/data-links/031784463981495d915c45cdf04790
+[debug] Response: GET http://localhost:3234/v2/data-links/031784463981495d915c45cdf04790 200
+[error] NotFound: Could not find internal flex service with identifier '031784463981495d915c45cdf04790'.
 
 `
 
-exports['flex delete when project is set with too many args should fail 1'] = `
-kinvey flex delete
+exports['flex delete when active profile is set and project config is set when one-time session and existent serviceId should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Logging in user: janeDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 200
+[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2
+[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2 200
+[debug] Request:  DELETE http://localhost:3234/v2/data-links/12378kdl2
+[debug] Response: DELETE http://localhost:3234/v2/data-links/12378kdl2 204
+[debug] Request:  DELETE http://localhost:3234/session
+[debug] Response: DELETE http://localhost:3234/session 204
+[debug] Logged out current user.
+Deleted service: 12378kdl2
 
-Delete project settings
+`
 
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instanceId              Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-
-Too many non-option arguments: got 1, maximum of 0
+exports['flex delete when profiles nor project config are set when one-time session and existent serviceId should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Logging in user: janeDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 200
+[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2
+[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2 200
+[debug] Request:  DELETE http://localhost:3234/v2/data-links/12378kdl2
+[debug] Response: DELETE http://localhost:3234/v2/data-links/12378kdl2 204
+[debug] Request:  DELETE http://localhost:3234/session
+[debug] Response: DELETE http://localhost:3234/session 204
+[debug] Logged out current user.
+Deleted service: 12378kdl2
 
 `

--- a/__snapshots__/flex-deploy.test.js
+++ b/__snapshots__/flex-deploy.test.js
@@ -1,7 +1,10 @@
 exports['flex deploy when project setup is non-existent by not specifying profile nor credentials when one profile should use it and fail 1'] = `
-kinvey flex deploy
+kinvey flex deploy [serviceId]
 
 Deploy the current project to the Kinvey FlexService Runtime
+
+Positionals:
+  serviceId  Service ID                                                 [string]
 
 Options:
   --version                 Show version number                        [boolean]
@@ -16,9 +19,8 @@ Options:
   --verbose                 Output debug messages                      [boolean]
   --no-color                Disable colors                             [boolean]
   -h, --help                Show help                                  [boolean]
-  --serviceId               Service ID                                  [string]
 
-This project is not configured. Use 'kinvey flex init' to get started. Alternatively, use options: serviceId.
+This project is not configured. Use 'kinvey flex init' to get started. Alternatively, use positional arguments: serviceId.
 
 `
 
@@ -28,9 +30,12 @@ exports['flex deploy when project setup exists is valid and user\'s project is i
 `
 
 exports['flex deploy when project setup exists is not valid and user\'s project is valid should fail 1'] = `
-kinvey flex deploy
+kinvey flex deploy [serviceId]
 
 Deploy the current project to the Kinvey FlexService Runtime
+
+Positionals:
+  serviceId  Service ID                                                 [string]
 
 Options:
   --version                 Show version number                        [boolean]
@@ -45,8 +50,7 @@ Options:
   --verbose                 Output debug messages                      [boolean]
   --no-color                Disable colors                             [boolean]
   -h, --help                Show help                                  [boolean]
-  --serviceId               Service ID                                  [string]
 
-This project is not configured. Use 'kinvey flex init' to get started. Alternatively, use options: serviceId.
+This project is not configured. Use 'kinvey flex init' to get started. Alternatively, use positional arguments: serviceId.
 
 `

--- a/__snapshots__/flex-logs.test.js
+++ b/__snapshots__/flex-logs.test.js
@@ -67,9 +67,12 @@ containerId   message                                                           
 `
 
 exports['flex logs without query by specifying a profile when project is not set without serviceId as an option should fail 1'] = `
-kinvey flex logs
+kinvey flex logs [serviceId]
 
 Retrieve and display Internal Flex Service logs
+
+Positionals:
+  serviceId  Service ID                                                 [string]
 
 Options:
   --version                 Show version number                        [boolean]
@@ -84,7 +87,6 @@ Options:
   --verbose                 Output debug messages                      [boolean]
   --no-color                Disable colors                             [boolean]
   -h, --help                Show help                                  [boolean]
-  --serviceId               Service ID                                  [string]
   --from                    Fetch log entries starting from provided timestamp
                                                                         [string]
   --to                      Fetch log entries up to provided timestamp  [string]
@@ -92,7 +94,7 @@ Options:
   --number, -n              Number of entries to fetch, i.e. page size (non-zero
                             integer, default=100, max=2000)             [number]
 
-This project is not configured. Use 'kinvey flex init' to get started. Alternatively, use options: serviceId.
+This project is not configured. Use 'kinvey flex init' to get started. Alternatively, use positional arguments: serviceId.
 
 `
 
@@ -160,9 +162,12 @@ exports['flex logs without query by not specifying profile nor credentials when 
 `
 
 exports['flex logs without query by not specifying profile nor credentials when several profiles and existent serviceId should fail 1'] = `
-kinvey flex logs
+kinvey flex logs [serviceId]
 
 Retrieve and display Internal Flex Service logs
+
+Positionals:
+  serviceId  Service ID                                                 [string]
 
 Options:
   --version                 Show version number                        [boolean]
@@ -177,7 +182,6 @@ Options:
   --verbose                 Output debug messages                      [boolean]
   --no-color                Disable colors                             [boolean]
   -h, --help                Show help                                  [boolean]
-  --serviceId               Service ID                                  [string]
   --from                    Fetch log entries starting from provided timestamp
                                                                         [string]
   --to                      Fetch log entries up to provided timestamp  [string]

--- a/__snapshots__/flex-recycle.test.js
+++ b/__snapshots__/flex-recycle.test.js
@@ -69,9 +69,12 @@ Recycle initiated. Job: idOfJobThatIsRecyclingTheService
 `
 
 exports['flex recycle by not specifying profile nor credentials when several profiles and existent serviceId should fail 1'] = `
-kinvey flex recycle
+kinvey flex recycle [serviceId]
 
 Recycle the Service
+
+Positionals:
+  serviceId  Service ID                                                 [string]
 
 Options:
   --version                 Show version number                        [boolean]
@@ -86,7 +89,6 @@ Options:
   --verbose                 Output debug messages                      [boolean]
   --no-color                Disable colors                             [boolean]
   -h, --help                Show help                                  [boolean]
-  --serviceId               Service ID                                  [string]
 
 You must be authenticated.
 

--- a/__snapshots__/flex-status.test.js
+++ b/__snapshots__/flex-status.test.js
@@ -30,9 +30,12 @@ exports['flex status by specifying a profile and non-existent serviceId should f
 `
 
 exports['flex status by not specifying profile nor credentials when several profiles and existent serviceId should fail 1'] = `
-kinvey flex status
+kinvey flex status [serviceId]
 
 Return the health of a Flex Service cluster
+
+Positionals:
+  serviceId  Service ID                                                 [string]
 
 Options:
   --version                 Show version number                        [boolean]
@@ -47,7 +50,6 @@ Options:
   --verbose                 Output debug messages                      [boolean]
   --no-color                Disable colors                             [boolean]
   -h, --help                Show help                                  [boolean]
-  --serviceId               Service ID                                  [string]
 
 You must be authenticated.
 
@@ -63,14 +65,14 @@ exports['flex status by specifying credentials as options when valid and existen
 [debug] Request:  DELETE http://localhost:3234/session
 [debug] Response: DELETE http://localhost:3234/session 204
 [debug] Logged out current user.
-key            value                                    
--------------  -----------------------------------------
-status         ONLINE                                   
-version        1.4.2                                    
-id             12378kdl2                                
-requestedAt    Wednesday, November 1st 2017, 10:42:31 AM
-deployerEmail  davy.jones@mail.com                      
-deployerName   Davy Jones                               
+key            value                                
+-------------  -------------------------------------
+status         ONLINE                               
+version        1.4.2                                
+id             12378kdl2                            
+requestedAt    replaced_value
+deployerEmail  davy.jones@mail.com                  
+deployerName   Davy Jones                           
 
 
 `
@@ -157,28 +159,6 @@ exports['flex status by not specifying profile nor credentials when one profile 
 [debug] Project configuration file not found: 'projectSetupPath'.
 [debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/status
 [debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/status 200
-key            value                                
--------------  -------------------------------------
-status         ONLINE                               
-version        1.4.2                                
-id             12378kdl2                            
-requestedAt    replaced_value
-deployerEmail  davy.jones@mail.com                  
-deployerName   Davy Jones                           
-
-
-`
-
-exports['flex status by specifying credentials as options when valid and existent serviceId should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Logging in user: janeyDoe@mail.com
-[debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 200
-[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/status
-[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/status 200
-[debug] Request:  DELETE http://localhost:3234/session
-[debug] Response: DELETE http://localhost:3234/session 204
-[debug] Logged out current user.
 key            value                                
 -------------  -------------------------------------
 status         ONLINE                               

--- a/lib/BaseController.js
+++ b/lib/BaseController.js
@@ -13,9 +13,31 @@
  * contents is a violation of applicable laws.
  */
 
+const { PromptTypes } = require('./Constants');
+
 class BaseController {
   constructor({ cliManager }) {
     this.cliManager = cliManager;
+  }
+
+  confirmDeleteOperation(noPrompt, entityType, identifier, done) {
+    if (noPrompt) {
+      return setImmediate(done);
+    }
+
+    const msg = `Are you sure you want to delete ${entityType} with identifier '${identifier}'?`;
+    const q = this.cliManager.prompter.buildQuestion(msg, 'confirmDelete', PromptTypes.CONFIRM, true);
+    this.cliManager.prompter.prompt(q, (err, data) => {
+      if (err) {
+        return done(err);
+      }
+
+      if (!data.confirmDelete) {
+        return done(new Error('Delete cancelled by user.'));
+      }
+
+      done();
+    });
   }
 }
 

--- a/lib/CLIManager.js
+++ b/lib/CLIManager.js
@@ -80,11 +80,11 @@ class CLIManager {
     this._controllers = {};
     this._controllers.init = new InitController({ cliManager: this });
     const flexService = new FlexService(this);
-    this._controllers[Namespace.FLEX] = new FlexController({ cliManager: this, flexService });
-    this._controllers[Namespace.PROFILE] = new ProfilesController({ cliManager: this });
-    const organizationsService = new OrganizationsService(this);
-    this._controllers[Namespace.ORG] = new OrganizationsController({ cliManager: this, organizationsService });
     const applicationsService = new ApplicationsService(this);
+    const organizationsService = new OrganizationsService(this);
+    this._controllers[Namespace.FLEX] = new FlexController({ cliManager: this, flexService, applicationsService, organizationsService });
+    this._controllers[Namespace.PROFILE] = new ProfilesController({ cliManager: this });
+    this._controllers[Namespace.ORG] = new OrganizationsController({ cliManager: this, organizationsService });
     this._controllers[Namespace.APP] = new ApplicationsController({ cliManager: this, applicationsService });
     const environmentsService = new EnvironmentsService(this);
     this._controllers[Namespace.ENV] = new EnvironmentsController({ cliManager: this, environmentsService, applicationsService });

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -162,8 +162,7 @@ Constants.FlexOptions = {
   [Constants.FlexOptionsNames.SERVICE_SECRET]: {
     global: false,
     describe: 'Shared secret',
-    type: 'string',
-    demandOption: true
+    type: 'string'
   },
   [Constants.FlexOptionsNames.DOMAIN_TYPE]: {
     global: false,

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -33,7 +33,9 @@ Constants.SubCommand = {
     LIST: 'list',
     LOGS: 'logs',
     RECYCLE: 'recycle',
-    DELETE: 'delete'
+    DELETE: 'delete',
+    CLEAR: 'clear',
+    CREATE: 'create'
   },
   [Constants.Namespace.ENV]: {
     SHOW: 'show',
@@ -50,6 +52,8 @@ Constants.Command = {
   FLEX_LOGS: `${Constants.Namespace.FLEX} ${Constants.SubCommand[Constants.Namespace.FLEX].LOGS}`,
   FLEX_RECYCLE: `${Constants.Namespace.FLEX} ${Constants.SubCommand[Constants.Namespace.FLEX].RECYCLE}`,
   FLEX_DELETE: `${Constants.Namespace.FLEX} ${Constants.SubCommand[Constants.Namespace.FLEX].DELETE}`,
+  FLEX_CLEAR: `${Constants.Namespace.FLEX} ${Constants.SubCommand[Constants.Namespace.FLEX].CLEAR}`,
+  FLEX_CREATE: `${Constants.Namespace.FLEX} ${Constants.SubCommand[Constants.Namespace.FLEX].CREATE}`,
   ENV_SHOW: `${Constants.Namespace.ENV} ${Constants.SubCommand[Constants.Namespace.ENV].SHOW}`,
   ENV_DELETE: `${Constants.Namespace.ENV} ${Constants.SubCommand[Constants.Namespace.ENV].DELETE}`,
 };
@@ -67,14 +71,24 @@ Constants.EnvironmentVariables.PASSWORD = `${Constants.EnvironmentVariables.PREF
 Constants.EnvironmentVariables.PROFILE = `${Constants.EnvironmentVariables.PREFIX}PROFILE`;
 Constants.EnvironmentVariables.HOST = `${Constants.EnvironmentVariables.PREFIX}HOST`;
 
-Constants.AllCommandsNotRequiringAuth = ['init', 'profile create', 'profile list', 'profile show', 'profile delete', 'profile use', 'profile login', 'flex delete'];
+Constants.AllCommandsNotRequiringAuth = ['init', 'profile create', 'profile list', 'profile show', 'profile delete', 'profile use', 'profile login', 'flex clear'];
 
 Constants.CommonOptionsNames = {
   NO_COLOR: 'no-color',
+  NO_PROMPT: 'no-prompt',
   OUTPUT: 'output',
   SILENT: 'silent',
   SUPPRESS_VERSION_CHECK: 'suppress-version-check',
   VERBOSE: 'verbose'
+};
+
+Constants.CommonOptions = {
+  [Constants.CommonOptionsNames.NO_PROMPT]: {
+    global: false,
+    describe: 'Do not prompt',
+    type: 'boolean',
+    default: false
+  }
 };
 
 Constants.OutputFormat = {
@@ -135,7 +149,8 @@ Constants.FlexOptionsNames = {
   TO: 'to',
   PAGE: 'page',
   NUMBER: 'number',
-  JOB_ID: 'id'
+  JOB_ID: 'id',
+  SERVICE_SECRET: 'secret'
 };
 
 Constants.FlexOptions = {
@@ -143,6 +158,12 @@ Constants.FlexOptions = {
     global: false,
     describe: 'Service ID',
     type: 'string'
+  },
+  [Constants.FlexOptionsNames.SERVICE_SECRET]: {
+    global: false,
+    describe: 'Shared secret',
+    type: 'string',
+    demandOption: true
   },
   [Constants.FlexOptionsNames.DOMAIN_TYPE]: {
     global: false,
@@ -393,7 +414,9 @@ Constants.EntityType = {
   ORG: 'organization',
   APP: 'application',
   ENV: 'environment',
-  COLL: 'collection'
+  COLL: 'collection',
+  SERVICE: 'service',
+  INTERNAL_FLEX_SERVICE: 'internal flex service'
 };
 
 Constants.Mapping = {};

--- a/lib/ProjectSetup.js
+++ b/lib/ProjectSetup.js
@@ -81,8 +81,8 @@ class ProjectSetup {
     delete this._setup[firstLevelKey].flex[propName];
   }
 
-  isServiceSetInFlexNamespace(firstLevelKey) {
-    return this._isPropertySetInFlexNamespace(firstLevelKey, 'serviceId') || this._isPropertySetInFlexNamespace(firstLevelKey, 'serviceName');
+  isServiceSetInFlexNamespace(firstLevelKey, serviceId) {
+    return this._isPropertySetInFlexNamespace(firstLevelKey, 'serviceId') && this.getFlexNamespace(firstLevelKey).serviceId === serviceId;
   }
 
   clearServiceInFlexNamespace(firstLevelKey) {

--- a/lib/ProjectSetup.js
+++ b/lib/ProjectSetup.js
@@ -71,6 +71,24 @@ class ProjectSetup {
 
     this._setup[key].flex.jobId = id;
   }
+
+  _isPropertySetInFlexNamespace(firstLevelKey, propName) {
+    return this._setup && !isEmpty(this._setup[firstLevelKey]) && !isEmpty(this._setup[firstLevelKey].flex)
+      && !isNullOrUndefined(this._setup[firstLevelKey].flex[propName]);
+  }
+
+  _clearPropertyInFlexNamespace(firstLevelKey, propName) {
+    delete this._setup[firstLevelKey].flex[propName];
+  }
+
+  isServiceSetInFlexNamespace(firstLevelKey) {
+    return this._isPropertySetInFlexNamespace(firstLevelKey, 'serviceId') || this._isPropertySetInFlexNamespace(firstLevelKey, 'serviceName');
+  }
+
+  clearServiceInFlexNamespace(firstLevelKey) {
+    const keysToRemove = ['serviceId', 'serviceName'];
+    keysToRemove.forEach(k => this._clearPropertyInFlexNamespace(firstLevelKey, k));
+  }
 }
 
 module.exports = ProjectSetup;

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -27,7 +27,7 @@ const lodashGet = require('lodash.get');
 const lodashSortBy = require('lodash.sortby');
 const logger = require('./logger.js');
 const moment = require('moment');
-const { ActiveItemTypes, Errors, PromptMessages } = require('./Constants');
+const { ActiveItemTypes, DomainTypes, Errors, PromptMessages } = require('./Constants');
 const KinveyError = require('./KinveyError');
 
 const Utils = {};
@@ -190,7 +190,10 @@ Utils.Endpoints = {
   envsByAppId: (schemaVersion, appId) => `${Utils.Endpoints.apps(schemaVersion, appId)}/environments`,
   collections: (schemaVersion, envId, collName) => `${Utils.Endpoints.envs(schemaVersion, envId)}/collections${Utils.Endpoints.getIdPartFromId(collName)}`,
   orgs: (schemaVersion, orgId) => `${Utils.Endpoints.version(schemaVersion)}/organizations${Utils.Endpoints.getIdPartFromId(orgId)}`,
-  servicesByDomain: (domainType, domainId, serviceId, schemaVersion) => `${Utils.Endpoints.version(schemaVersion)}/${domainType}/${domainId}/data-links`,
+  servicesByDomain: (domainType, domainId, schemaVersion) => {
+    const domain = domainType === DomainTypes.APP ? 'apps' : 'organizations';
+    return `${Utils.Endpoints.version(schemaVersion)}/${domain}/${domainId}/data-links`;
+  },
   jobs: (schemaVersion, id) => `${Utils.Endpoints.version(schemaVersion)}/jobs${Utils.Endpoints.getIdPartFromId(id)}`,
   services: (schemaVersion, serviceId) => `${Utils.Endpoints.version(schemaVersion)}/data-links/${serviceId}`,
   serviceStatus: (schemaVersion, serviceId) => `${Utils.Endpoints.services(schemaVersion, serviceId)}/status`,

--- a/lib/application/ApplicationsController.js
+++ b/lib/application/ApplicationsController.js
@@ -17,7 +17,7 @@ const async = require('async');
 
 const BaseController = require('../BaseController');
 const CommandResult = require('../CommandResult');
-const { ActiveItemType, AppOptionsName, EntityType, Mapping, OperationType } = require('../Constants');
+const { ActiveItemType, AppOptionsName, CommonOptionsNames, EntityType, Mapping, OperationType } = require('../Constants');
 const KinveyError = require('../KinveyError');
 const { isNullOrUndefined, getItemError, mapFromSource, sortList } = require('../Utils');
 
@@ -120,6 +120,9 @@ class ApplicationsController extends BaseController {
     let id;
 
     async.series([
+      (next) => {
+        super.confirmDeleteOperation(options[CommonOptionsNames.NO_PROMPT], EntityType.APP, appIdentifier, next);
+      },
       (next) => {
         this.applicationsService.removeByIdOrName(appIdentifier, (err, removedId) => {
           if (err) {

--- a/lib/application/applicationsRouter.js
+++ b/lib/application/applicationsRouter.js
@@ -13,7 +13,7 @@
  * contents is a violation of applicable laws.
  */
 
-const { AppOptions, AppOptionsName, CommandRequirement, Namespace } = require('./../Constants');
+const { AppOptions, AppOptionsName, CommandRequirement, CommonOptions, CommonOptionsNames, Namespace } = require('./../Constants');
 
 const cmdDefinitions = [
   {
@@ -57,7 +57,8 @@ const cmdDefinitions = [
     desc: 'Delete a specified app or the active one',
     builder: (commandsManager) => {
       commandsManager
-        .positional(AppOptionsName.APP, AppOptions[AppOptionsName.APP]);
+        .positional(AppOptionsName.APP, AppOptions[AppOptionsName.APP])
+        .option(CommonOptionsNames.NO_PROMPT, CommonOptions[CommonOptionsNames.NO_PROMPT]);
     },
     handlerName: 'deleteApp',
     requirements: [CommandRequirement.AUTH]

--- a/lib/collection/CollectionsController.js
+++ b/lib/collection/CollectionsController.js
@@ -17,7 +17,7 @@ const async = require('async');
 
 const BaseController = require('../BaseController');
 const CommandResult = require('../CommandResult');
-const { ActiveItemType, AppOptionsName, CollectionOptionsName, EntityType, EnvOptionsName, Errors, OperationType } = require('../Constants');
+const { ActiveItemType, AppOptionsName, CollectionOptionsName, CommonOptionsNames, EntityType, EnvOptionsName, Errors, OperationType } = require('../Constants');
 const KinveyError = require('../KinveyError');
 const { isNullOrUndefined, sortList } = require('../Utils');
 
@@ -99,6 +99,9 @@ class CollectionsController extends BaseController {
     const identifier = options[CollectionOptionsName.COLL];
 
     async.waterfall([
+      (next) => {
+        super.confirmDeleteOperation(options[CommonOptionsNames.NO_PROMPT], EntityType.COLL, identifier, next);
+      },
       (next) => {
         this.environmentsService.getActiveOrSpecified(options, next);
       },

--- a/lib/collection/collectionsRouter.js
+++ b/lib/collection/collectionsRouter.js
@@ -13,7 +13,7 @@
  * contents is a violation of applicable laws.
  */
 
-const { AppOptions, AppOptionsName, CollectionOptions, CollectionOptionsName, CommandRequirement, EnvOptions, EnvOptionsName, Namespace } = require('./../Constants');
+const { AppOptions, AppOptionsName, CollectionOptions, CollectionOptionsName, CommonOptions, CommonOptionsNames, CommandRequirement, EnvOptions, EnvOptionsName, Namespace } = require('./../Constants');
 
 const cmdDefinitions = [
   {
@@ -46,7 +46,8 @@ const cmdDefinitions = [
       commandsManager
         .positional(CollectionOptionsName.COLL, CollectionOptions[CollectionOptionsName.COLL])
         .option(EnvOptionsName.ENV, EnvOptions[EnvOptionsName.ENV])
-        .option(AppOptionsName.APP, AppOptions[AppOptionsName.APP]);
+        .option(AppOptionsName.APP, AppOptions[AppOptionsName.APP])
+        .option(CommonOptionsNames.NO_PROMPT, CommonOptions[CommonOptionsNames.NO_PROMPT]);
     },
     handlerName: 'deleteCollection',
     requirements: [CommandRequirement.AUTH]

--- a/lib/environment/EnvironmentsController.js
+++ b/lib/environment/EnvironmentsController.js
@@ -17,7 +17,7 @@ const async = require('async');
 
 const BaseController = require('../BaseController');
 const CommandResult = require('../CommandResult');
-const { ActiveItemType, AppOptionsName, EntityType, EnvOptionsName, Errors, Mapping, OperationType } = require('../Constants');
+const { ActiveItemType, AppOptionsName, CommonOptionsNames, EntityType, EnvOptionsName, Errors, Mapping, OperationType } = require('../Constants');
 const KinveyError = require('../KinveyError');
 const { getCommandNameFromOptions, isNullOrUndefined, mapFromSource, sortList } = require('../Utils');
 
@@ -169,6 +169,15 @@ class EnvironmentsController extends BaseController {
           }
 
           next(null, data.id);
+        });
+      },
+      (envId, next) => {
+        super.confirmDeleteOperation(options[CommonOptionsNames.NO_PROMPT], EntityType.ENV, envId, (err) => {
+          if (err) {
+            return next(err);
+          }
+
+          next(null, envId);
         });
       },
       (envId, next) => {

--- a/lib/environment/environmentsRouter.js
+++ b/lib/environment/environmentsRouter.js
@@ -13,7 +13,7 @@
  * contents is a violation of applicable laws.
  */
 
-const { AppOptions, AppOptionsName, CommandRequirement, EnvOptions, EnvOptionsName, Namespace } = require('./../Constants');
+const { AppOptions, AppOptionsName, CommandRequirement, CommonOptions, CommonOptionsNames, EnvOptions, EnvOptionsName, Namespace } = require('./../Constants');
 
 const cmdDefinitions = [
   {
@@ -65,7 +65,8 @@ const cmdDefinitions = [
     builder: (commandsManager) => {
       commandsManager
         .positional(EnvOptionsName.ENV, EnvOptions[EnvOptionsName.ENV])
-        .option(AppOptionsName.APP, AppOptions[AppOptionsName.APP]);
+        .option(AppOptionsName.APP, AppOptions[AppOptionsName.APP])
+        .option(CommonOptionsNames.NO_PROMPT, CommonOptions[CommonOptionsNames.NO_PROMPT]);
     },
     handlerName: 'deleteEnv',
     requirements: [CommandRequirement.AUTH]

--- a/lib/flex/FlexController.js
+++ b/lib/flex/FlexController.js
@@ -399,23 +399,7 @@ class FlexController extends BaseController {
 
     async.series([
       (next) => {
-        if (options[CommonOptionsNames.NO_PROMPT]) {
-          return setImmediate(next);
-        }
-
-        const msg = `Are you sure you want to delete service with identifier '${serviceId}'?`;
-        const q = this.cliManager.prompter.buildQuestion(msg, 'confirmDelete', PromptTypes.CONFIRM, true);
-        this.cliManager.prompter.prompt(q, (err, data) => {
-          if (err) {
-            return next(err);
-          }
-
-          if (!data.confirmDelete) {
-            return next(new Error('Delete cancelled by user.'));
-          }
-
-          next();
-        });
+        super.confirmDeleteOperation(options[CommonOptionsNames.NO_PROMPT], EntityType.SERVICE, serviceId, next);
       },
       (next) => {
         this.flexService.deleteServiceById(serviceId, next);

--- a/lib/flex/FlexController.js
+++ b/lib/flex/FlexController.js
@@ -412,7 +412,7 @@ class FlexController extends BaseController {
       },
       (next) => {
         const currentProfile = this.cliManager.getCurrentProfileName();
-        if (!currentProfile || !this.projectSetup.isServiceSetInFlexNamespace(currentProfile)) {
+        if (!currentProfile || !this.projectSetup.isServiceSetInFlexNamespace(currentProfile, serviceId)) {
           return setImmediate(next);
         }
 

--- a/lib/flex/FlexController.js
+++ b/lib/flex/FlexController.js
@@ -156,7 +156,6 @@ class FlexController extends BaseController {
    * @param done
    */
   init(options, done) {
-    console.log(options);
     async.series([
       (next) => {
         let err = null;
@@ -294,10 +293,12 @@ class FlexController extends BaseController {
         }
       },
       (entity, next) => {
+        const secret = !isNullOrUndefined(options[FlexOptionsNames.SERVICE_SECRET])
+          ? options[FlexOptionsNames.SERVICE_SECRET] : this.flexService.generateSecret();
         const data = {
           name: options.name,
           type: 'internal',
-          backingServers: [{ secret: options[FlexOptionsNames.SERVICE_SECRET] }]
+          backingServers: [{ secret }]
         };
 
         this.flexService.createService(data, entity.id, domainType, next);
@@ -307,9 +308,14 @@ class FlexController extends BaseController {
         return done(err);
       }
 
+      const rawResult = {
+        id: result.id,
+        secret: result.backingServers[0].secret
+      };
+      const msg = `Created service: ${rawResult.id}. Secret: ${rawResult.secret}`;
       const cmdResult = new CommandResult()
-        .setRawData({ id: result.id })
-        .setBasicMsg(OperationType.CREATE, EntityType.SERVICE, result.id);
+        .setRawData(rawResult)
+        .setCustomMsg(msg);
       done(null, cmdResult);
     });
   }

--- a/lib/flex/FlexController.js
+++ b/lib/flex/FlexController.js
@@ -18,7 +18,7 @@ const chalk = require('chalk');
 
 const BaseController = require('../BaseController');
 const ProjectSetup = require('../ProjectSetup');
-const { Command, Errors, EntityType, DomainTypes, LogLevel, OperationType, FlexOptionsNames, FlexProjectMaxSize, JobStatus } = require('../Constants');
+const { AppOptionsName, Command, CommonOptionsNames, Errors, EntityType, DomainTypes, LogLevel, OperationType, OrgOptionsName, PromptTypes, FlexOptionsNames, FlexProjectMaxSize, JobStatus } = require('../Constants');
 const CommandResult = require('../CommandResult');
 const KinveyError = require('../KinveyError');
 const { getCommandNameFromOptions, isNullOrUndefined } = require('../Utils');
@@ -36,6 +36,8 @@ class FlexController extends BaseController {
   constructor(options) {
     super(options);
     this.flexService = options.flexService;
+    this.applicationsService = options.applicationsService;
+    this.organizationsService = options.organizationsService;
     this.projectSetup = new ProjectSetup(this.cliManager.config.paths.project);
     this._metadata = {
       serviceName: null,
@@ -57,12 +59,13 @@ class FlexController extends BaseController {
   }
 
   _validateCommandOptions(cmd, options, projectSetup = {}) {
-    const serviceIdIsRequired = cmd === Command.FLEX_DEPLOY || cmd === Command.FLEX_STATUS || cmd === Command.FLEX_LOGS || cmd === Command.FLEX_RECYCLE;
+    const serviceIdIsRequired = cmd === Command.FLEX_DEPLOY || cmd === Command.FLEX_STATUS || cmd === Command.FLEX_LOGS
+      || cmd === Command.FLEX_RECYCLE || cmd === Command.FLEX_DELETE;
     if (serviceIdIsRequired) {
       this._metadata[FlexOptionsNames.SERVICE_ID] = options[FlexOptionsNames.SERVICE_ID] || projectSetup[FlexOptionsNames.SERVICE_ID];
 
       if (isNullOrUndefined(this._metadata[FlexOptionsNames.SERVICE_ID])) {
-        return FlexController._getValidationErr(FlexOptionsNames.SERVICE_ID);
+        return FlexController._getValidationErr(FlexOptionsNames.SERVICE_ID, true);
       }
     }
 
@@ -70,7 +73,7 @@ class FlexController extends BaseController {
     if (jobIdIsRequired) {
       this._metadata.jobId = options[FlexOptionsNames.JOB_ID] || projectSetup.jobId;
       if (isNullOrUndefined(this._metadata.jobId)) {
-        return FlexController._getValidationErr(FlexOptionsNames.JOB_ID);
+        return FlexController._getValidationErr(FlexOptionsNames.JOB_ID, true);
       }
     }
 
@@ -84,9 +87,10 @@ class FlexController extends BaseController {
     }
   }
 
-  static _getValidationErr(keys) {
+  static _getValidationErr(keys, isPositionalArg) {
     keys = Array.isArray(keys) ? keys : [keys];
-    const errMsg = `${Errors.ProjectNotConfigured.MESSAGE} Alternatively, use options: ${keys.join(', ')}.`;
+    const typeMsg = isPositionalArg ? 'positional arguments' : 'options';
+    const errMsg = `${Errors.ProjectNotConfigured.MESSAGE} Alternatively, use ${typeMsg}: ${keys.join(', ')}.`;
     return new KinveyError(Errors.ProjectNotConfigured.NAME, errMsg);
   }
 
@@ -98,10 +102,10 @@ class FlexController extends BaseController {
    */
   preProcessOptions(options) {
     const cmd = getCommandNameFromOptions(options);
-    const cmdIsDelete = cmd === Command.FLEX_DELETE;
+    const cmdIsDeleteProjectSetup = cmd === Command.FLEX_CLEAR;
 
     // no need to load setup or validate anything
-    if (cmdIsDelete) {
+    if (cmdIsDeleteProjectSetup) {
       return true;
     }
 
@@ -111,12 +115,12 @@ class FlexController extends BaseController {
     const errOptionsValidation = this._validateCommandOptions(cmd, options);
 
     // validation failed and there's no point in loading setup
-    if (errOptionsValidation && this.cliManager.isOneTimeSession()) {
+    if (errOptionsValidation && (this.cliManager.isOneTimeSession() || cmd === Command.FLEX_CREATE)) {
       throw errOptionsValidation;
     }
 
     // try loading setup as we might need it if not a one-time session
-    if (!this.cliManager.isOneTimeSession()) {
+    if (!this.cliManager.isOneTimeSession() && cmd !== Command.FLEX_CREATE) {
       const errSetupLoad = this.projectSetup.load();
       if (errSetupLoad) {
         const debugMsg = errSetupLoad.code === 'ENOENT' ? `Project configuration file not found: '${errSetupLoad.path}'.` : errSetupLoad;
@@ -152,6 +156,7 @@ class FlexController extends BaseController {
    * @param done
    */
   init(options, done) {
+    console.log(options);
     async.series([
       (next) => {
         let err = null;
@@ -270,14 +275,52 @@ class FlexController extends BaseController {
     });
   }
 
+  create(options, done) {
+    let domainType;
+
+    async.waterfall([
+      (next) => {
+        const appIsSet = !isNullOrUndefined(options[AppOptionsName.APP]);
+        const orgIsSet = !isNullOrUndefined(options[OrgOptionsName.ORG]);
+        if (appIsSet) {
+          domainType = DomainTypes.APP;
+          this.applicationsService.getByIdOrName(options[AppOptionsName.APP], next);
+        } else if (orgIsSet) {
+          domainType = DomainTypes.ORG;
+          this.organizationsService.getByIdOrName(options[OrgOptionsName.ORG], next);
+        } else {
+          const errMsg = `Either '--${AppOptionsName.APP}' or '--${OrgOptionsName.ORG}' option must be set.`;
+          return setImmediate(() => next(new Error(errMsg)));
+        }
+      },
+      (entity, next) => {
+        const data = {
+          name: options.name,
+          type: 'internal',
+          backingServers: [{ secret: options[FlexOptionsNames.SERVICE_SECRET] }]
+        };
+
+        this.flexService.createService(data, entity.id, domainType, next);
+      }
+    ], (err, result) => {
+      if (err) {
+        return done(err);
+      }
+
+      const cmdResult = new CommandResult()
+        .setRawData({ id: result.id })
+        .setBasicMsg(OperationType.CREATE, EntityType.SERVICE, result.id);
+      done(null, cmdResult);
+    });
+  }
+
   list(options, done) {
-    const isDomainApp = this._metadata.domain === DomainTypes.APP;
     const domainEntity = {
       id: this._metadata.domainEntityId,
       schemaVersion: this._metadata.schemaVersion
     };
 
-    this.flexService.getServices(isDomainApp, domainEntity, (err, services) => {
+    this.flexService.getServices(this._metadata.domain, domainEntity, (err, services) => {
       if (err) {
         return done(err);
       }
@@ -347,6 +390,61 @@ class FlexController extends BaseController {
       const cmdResult = new CommandResult()
         .setRawData({ id: jobId })
         .setCustomMsg(userFriendlyMsg);
+      done(null, cmdResult);
+    });
+  }
+
+  deleteService(options, done) {
+    const serviceId = this._metadata[FlexOptionsNames.SERVICE_ID];
+
+    async.series([
+      (next) => {
+        if (options[CommonOptionsNames.NO_PROMPT]) {
+          return setImmediate(next);
+        }
+
+        const msg = `Are you sure you want to delete service with identifier '${serviceId}'?`;
+        const q = this.cliManager.prompter.buildQuestion(msg, 'confirmDelete', PromptTypes.CONFIRM, true);
+        this.cliManager.prompter.prompt(q, (err, data) => {
+          if (err) {
+            return next(err);
+          }
+
+          if (!data.confirmDelete) {
+            return next(new Error('Delete cancelled by user.'));
+          }
+
+          next();
+        });
+      },
+      (next) => {
+        this.flexService.deleteServiceById(serviceId, next);
+      },
+      (next) => {
+        const currentProfile = this.cliManager.getCurrentProfileName();
+        if (!currentProfile || !this.projectSetup.isServiceSetInFlexNamespace(currentProfile)) {
+          return setImmediate(next);
+        }
+
+        this.projectSetup.clearServiceInFlexNamespace(currentProfile);
+        this.projectSetup.save((err) => {
+          if (err) {
+            this.cliManager.log(LogLevel.WARN, `Failed to delete service from project settings. ${err}`);
+          } else {
+            this.cliManager.log(LogLevel.DEBUG, 'Deleted service from project settings.');
+          }
+
+          next();
+        });
+      }
+    ], (err) => {
+      if (err) {
+        return done(err);
+      }
+
+      const cmdResult = new CommandResult()
+        .setRawData({ id: serviceId })
+        .setBasicMsg(OperationType.DELETE, EntityType.SERVICE);
       done(null, cmdResult);
     });
   }

--- a/lib/flex/FlexService.js
+++ b/lib/flex/FlexService.js
@@ -20,10 +20,10 @@ const moment = require('moment');
 const archiver = require('archiver');
 const path = require('path');
 
-const { DomainTypes, Errors, FlexOptionsNames, HTTPMethod, InfoMessages, LogErrorMessages, LogLevel, PromptMessages, PromptTypes, ServiceStatus } = require('../Constants');
+const { DomainTypes, EntityType, Errors, FlexOptionsNames, HTTPMethod, InfoMessages, LogErrorMessages, LogLevel, PromptMessages, PromptTypes, ServiceStatus } = require('../Constants');
 const BaseService = require('./../BaseService');
 const KinveyError = require('../KinveyError');
-const { Endpoints, formatList, findAndSortInternalServices, isArtifact, isEmpty, isNullOrUndefined, isValidNonZeroInteger, isValidTimestamp, readJSON } = require('../Utils');
+const { Endpoints, formatList, findAndSortInternalServices, getCustomNotFoundError, isArtifact, isEmpty, isNullOrUndefined, isValidNonZeroInteger, isValidTimestamp, readJSON } = require('../Utils');
 
 class FlexService extends BaseService {
   static paintServiceStatus(status) {
@@ -73,11 +73,12 @@ class FlexService extends BaseService {
   /**
    * Gets the user's choice of specific domain entity (specific app or org).
    * @param {Array} entities
-   * @param {Boolean} isAppDomain
+   * @param {Constants.DomainTypes} domainType
    * @param done
    * @private
    */
-  _getDomainEntityChoice(entities, isAppDomain, done) {
+  _getDomainEntityChoice(entities, domainType, done) {
+    const isAppDomain = domainType === DomainTypes.APP;
     const logMsg = isAppDomain ? InfoMessages.APP_PROMPTING : InfoMessages.ORG_PROMPTING;
     this.cliManager.log(LogLevel.DEBUG, logMsg);
     const msg = isAppDomain ? PromptMessages.INPUT_APP : PromptMessages.INPUT_ORG;
@@ -144,14 +145,14 @@ class FlexService extends BaseService {
 
   /**
    * Gets all the internal services (sorted) for a domain. If none found, passes an error to callback.
-   * @param {Boolean} isDomainApp
+   * @param {Constants.DomainTypes} domainType
    * @param {Object} entity
    * @param done
    * @private
    */
-  getServices(isDomainApp, entity, done) {
-    const domainType = isDomainApp ? 'apps' : 'organizations';
-    const endpoint = Endpoints.servicesByDomain(domainType, entity.id, null, entity.schemaVersion);
+  getServices(domainType, entity, done) {
+    const schemaVersion = entity.schemaVersion || this.cliManager.config.defaultSchemaVersion;
+    const endpoint = Endpoints.servicesByDomain(domainType, entity.id, schemaVersion);
     this.cliManager.sendRequest({ endpoint }, (err, data) => {
       if (err) {
         return done(err);
@@ -255,14 +256,13 @@ class FlexService extends BaseService {
       },
       (domain, next) => {
         const entities = allDomainEntities[domain];
-        isAppDomain = domain === DomainTypes.APP;
-        this._getDomainEntityChoice(entities, isAppDomain, next);
+        this._getDomainEntityChoice(entities, domain, next);
       },
       (entity, next) => {
         entity.schemaVersion = entity.schemaVersion || this.cliManager.config.defaultSchemaVersion;
         input.schemaVersion = entity.schemaVersion;
         input.domainEntityId = entity.id;
-        this.getServices(isAppDomain, entity, next);
+        this.getServices(input.domain, entity, next);
       },
       (services, next) => {
         this._getServiceChoice(services, (err, data) => {
@@ -360,6 +360,11 @@ class FlexService extends BaseService {
     ]);
 
     archive.finalize();
+  }
+
+  createService(data, domainId, domainType, done) {
+    const endpoint = Endpoints.servicesByDomain(domainType, domainId, this.cliManager.config.defaultSchemaVersion);
+    this.cliManager.sendRequest({ endpoint, data, method: HTTPMethod.POST }, done);
   }
 
   _getJob(jobId, schemaVersion, done) {
@@ -517,6 +522,33 @@ class FlexService extends BaseService {
 
       done(null, data.job);
     });
+  }
+
+  getServiceById(id, done) {
+    this.cliManager.sendRequest({ endpoint: Endpoints.services(this.cliManager.config.defaultSchemaVersion, id) }, done);
+  }
+
+  deleteServiceById(id, done) {
+    async.series([
+      (next) => {
+        this.getServiceById(id, (err, service) => {
+          if (err) {
+            return next(err);
+          }
+
+          const isInternalFlex = service && service.type === 'internal';
+          if (!isInternalFlex) {
+            return setImmediate(() => { next(getCustomNotFoundError(EntityType.INTERNAL_FLEX_SERVICE, id)); });
+          }
+
+          next();
+        });
+      },
+      (next) => {
+        const endpoint = Endpoints.services(this.cliManager.config.defaultSchemaVersion, id);
+        this.cliManager.sendRequest({ endpoint, method: HTTPMethod.DELETE }, next);
+      }
+    ], done);
   }
 }
 

--- a/lib/flex/FlexService.js
+++ b/lib/flex/FlexService.js
@@ -13,6 +13,7 @@
  * contents is a violation of applicable laws.
  */
 
+const AESjs = require('aes-js');
 const async = require('async');
 const chalk = require('chalk');
 const moment = require('moment');
@@ -360,6 +361,32 @@ class FlexService extends BaseService {
     ]);
 
     archive.finalize();
+  }
+
+  /**
+   * Returns secret key. 256-bit key derived from 58 digit key.
+   * @returns {String}
+   */
+  // eslint-disable-next-line class-methods-use-this
+  generateSecret() {
+    let ret = '';
+    const length = 58;
+    while (ret.length < length) {
+      ret += Math.random().toString(16).substring(2);
+    }
+
+    const text = ret.substring(0, length);
+
+    const key256 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+      16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+      29, 30, 31];
+    const textBytes = AESjs.utils.utf8.toBytes(text);
+
+    // The counter is optional, and if omitted will begin at 1
+    const aesCtr = new AESjs.ModeOfOperation.ctr(key256, new AESjs.Counter(5)); // eslint-disable-line
+    const encryptedBytes = aesCtr.encrypt(textBytes);
+    const result = AESjs.utils.hex.fromBytes(encryptedBytes);
+    return result;
   }
 
   createService(data, domainId, domainType, done) {

--- a/lib/flex/flexRouter.js
+++ b/lib/flex/flexRouter.js
@@ -129,7 +129,7 @@ const cmdDefinitions = [
     desc: 'Delete service',
     builder: (commandsManager) => {
       commandsManager
-        .positional(FlexOptionsNames.SERVICE_ID, { describe: FlexOptions[FlexOptionsNames.SERVICE_ID].describe })
+        .positional(FlexOptionsNames.SERVICE_ID, FlexOptions[FlexOptionsNames.SERVICE_ID])
         .option(CommonOptionsNames.NO_PROMPT, CommonOptions[CommonOptionsNames.NO_PROMPT]);
     },
     handlerName: 'deleteService',

--- a/lib/flex/flexRouter.js
+++ b/lib/flex/flexRouter.js
@@ -13,7 +13,7 @@
  * contents is a violation of applicable laws.
  */
 
-const { CommandRequirement, FlexOptions, FlexOptionsNames, Namespace } = require('../Constants');
+const { AppOptions, AppOptionsName, CommandRequirement, CommonOptions, CommonOptionsNames, FlexOptions, FlexOptionsNames, Namespace, OrgOptions, OrgOptionsName, SubCommand } = require('../Constants');
 
 const cmdDefinitions = [
   {
@@ -22,11 +22,25 @@ const cmdDefinitions = [
     handlerName: 'init'
   },
   {
-    command: 'deploy',
+    command: 'create <name>',
+    desc: 'Create a Flex service',
+    builder: (commandsManager) => {
+      commandsManager
+        .positional('name', { describe: 'Flex service name' })
+        .option(AppOptionsName.APP, AppOptions[AppOptionsName.APP])
+        .option(OrgOptionsName.ORG, OrgOptions[OrgOptionsName.ORG])
+        .option(FlexOptionsNames.SERVICE_SECRET, FlexOptions[FlexOptionsNames.SERVICE_SECRET])
+        .conflicts(AppOptionsName.APP, OrgOptionsName.ORG);
+    },
+    handlerName: 'create',
+    requirements: [CommandRequirement.AUTH]
+  },
+  {
+    command: `deploy [${FlexOptionsNames.SERVICE_ID}]`,
     desc: 'Deploy the current project to the Kinvey FlexService Runtime',
     builder: (commandsManager) => {
       commandsManager
-        .option(FlexOptionsNames.SERVICE_ID, FlexOptions[FlexOptionsNames.SERVICE_ID]);
+        .positional(FlexOptionsNames.SERVICE_ID, FlexOptions[FlexOptionsNames.SERVICE_ID]);
     },
     handlerName: 'deploy',
     requirements: [CommandRequirement.AUTH]
@@ -42,11 +56,11 @@ const cmdDefinitions = [
     requirements: [CommandRequirement.AUTH]
   },
   {
-    command: 'status',
+    command: `status [${FlexOptionsNames.SERVICE_ID}]`,
     desc: 'Return the health of a Flex Service cluster',
     builder: (commandsManager) => {
       commandsManager
-        .option(FlexOptionsNames.SERVICE_ID, FlexOptions[FlexOptionsNames.SERVICE_ID]);
+        .positional(FlexOptionsNames.SERVICE_ID, FlexOptions[FlexOptionsNames.SERVICE_ID]);
     },
     handlerName: 'status',
     requirements: [CommandRequirement.AUTH]
@@ -63,14 +77,14 @@ const cmdDefinitions = [
     requirements: [CommandRequirement.AUTH]
   },
   {
-    command: 'logs',
+    command: `logs [${FlexOptionsNames.SERVICE_ID}]`,
     desc: 'Retrieve and display Internal Flex Service logs',
     builder: (commandsManager, cliManager) => {
       const logFetchDefault = cliManager.config.logFetchDefault;
       const logFetchLimit = cliManager.config.logFetchLimit;
 
       commandsManager
-        .option(FlexOptionsNames.SERVICE_ID, FlexOptions[FlexOptionsNames.SERVICE_ID])
+        .positional(FlexOptionsNames.SERVICE_ID, FlexOptions[FlexOptionsNames.SERVICE_ID])
         .option(
           FlexOptionsNames.FROM, {
             global: false,
@@ -101,18 +115,29 @@ const cmdDefinitions = [
     requirements: [CommandRequirement.AUTH]
   },
   {
-    command: 'recycle',
+    command: `recycle [${FlexOptionsNames.SERVICE_ID}]`,
     desc: 'Recycle the Service',
     builder: (commandsManager) => {
       commandsManager
-        .option(FlexOptionsNames.SERVICE_ID, FlexOptions[FlexOptionsNames.SERVICE_ID]);
+        .positional(FlexOptionsNames.SERVICE_ID, FlexOptions[FlexOptionsNames.SERVICE_ID]);
     },
     handlerName: 'recycle',
     requirements: [CommandRequirement.AUTH]
   },
   {
-    command: 'delete',
-    desc: 'Delete project settings',
+    command: `delete [${FlexOptionsNames.SERVICE_ID}]`,
+    desc: 'Delete service',
+    builder: (commandsManager) => {
+      commandsManager
+        .positional(FlexOptionsNames.SERVICE_ID, { describe: FlexOptions[FlexOptionsNames.SERVICE_ID].describe })
+        .option(CommonOptionsNames.NO_PROMPT, CommonOptions[CommonOptionsNames.NO_PROMPT]);
+    },
+    handlerName: 'deleteService',
+    requirements: [CommandRequirement.AUTH]
+  },
+  {
+    command: SubCommand[Namespace.FLEX].CLEAR,
+    desc: 'Clear project settings',
     handlerName: 'deleteProjectSetup'
   }
 ];

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint": "./node_modules/.bin/eslint bin config lib test"
   },
   "dependencies": {
+    "aes-js": "3.1.1",
     "archiver": "1.0.1",
     "async": "1.4.2",
     "chalk": "2.1.0",

--- a/test/TestsHelper.js
+++ b/test/TestsHelper.js
@@ -114,7 +114,7 @@ TestsHelper.assertions = {
   assertProjectSetup(expected, path, done) {
     path = path || projectPath;
     readJSON(path, (err, actual) => {
-      if (err) {
+      if (err && err.code !== 'ENOENT') {
         return done(err);
       }
 
@@ -341,7 +341,7 @@ TestsHelper.setup = {
     });
   },
 
-  setActiveItemOnProfile(profileName, entityType, activeItem, path, done) {
+  setActiveItemOnProfile(profileName, activeItemType, activeItem, path, done) {
     path = path || globalSetupPath;
     TestsHelper.setup._readGlobalSetupForProfile(profileName, path, (err, setup) => {
       if (err) {
@@ -352,7 +352,7 @@ TestsHelper.setup = {
         setup.profiles[profileName].active = {};
       }
 
-      setup.profiles[profileName].active[entityType] = activeItem;
+      setup.profiles[profileName].active[activeItemType] = activeItem;
       writeJSON(path, setup, done);
     });
   },

--- a/test/fixtures/internal-flex-service.json
+++ b/test/fixtures/internal-flex-service.json
@@ -1,0 +1,10 @@
+{
+  "id"  : "12378kdl2",
+  "type" : "internal",
+  "name" : "TestKinveyDatalink",
+  "backingServers": [{
+    "_id"    : "456",
+    "host"   : "k8s-d0f34091237849ac5253",
+    "secret" : "789"
+  }]
+}

--- a/test/integration/commands/application/app-delete.test.js
+++ b/test/integration/commands/application/app-delete.test.js
@@ -29,6 +29,8 @@ const appName = fixtureApp.name;
 const appId = fixtureApp.id;
 
 function testAppDelete(options, flags, identifier, done) {
+  flags = flags || [];
+  flags.push(CommonOptionsNames.NO_PROMPT);
   testers.execCmdWithIdentifier(baseCmd, options, flags, identifier, null, done);
 }
 

--- a/test/integration/commands/collection/coll-delete.test.js
+++ b/test/integration/commands/collection/coll-delete.test.js
@@ -15,7 +15,7 @@
 
 const async = require('async');
 
-const { ActiveItemType, AppOptionsName, AuthOptionsNames, EnvOptionsName, Namespace } = require('./../../../../lib/Constants');
+const { ActiveItemType, AppOptionsName, AuthOptionsNames, CommonOptionsNames, EnvOptionsName, Namespace } = require('./../../../../lib/Constants');
 const { buildCmd, execCmdWithAssertion, setup, testers } = require('../../../TestsHelper');
 const fixtureApp = require('./../../../fixtures/app.json');
 const fixtureEnv = require('./../../../fixtures/env.json');
@@ -41,6 +41,8 @@ function testCollCreate(options, flags, envIdentifier, appIdentifier, collName, 
     mergedOptions[EnvOptionsName.ENV] = envIdentifier;
   }
 
+  flags = flags || [];
+  flags.push(CommonOptionsNames.NO_PROMPT);
   testers.execCmdWithIdentifier(baseCmd, mergedOptions, flags, collName, null, done);
 }
 
@@ -64,7 +66,7 @@ describe(baseCmd, () => {
         [AppOptionsName.APP]: fixtureApp.name,
         [EnvOptionsName.ENV]: fixtureEnv.name
       };
-      const cmd = buildCmd(baseCmd, [fixtureColl.name], options, defaultFlags);
+      const cmd = buildCmd(baseCmd, [fixtureColl.name], options, [CommonOptionsNames.VERBOSE, CommonOptionsNames.NO_PROMPT]);
       execCmdWithAssertion(cmd, null, null, true, true, false, null, (err) => {
         expect(err).to.not.exist;
         done();

--- a/test/integration/commands/environment/env-delete.test.js
+++ b/test/integration/commands/environment/env-delete.test.js
@@ -15,7 +15,7 @@
 
 const async = require('async');
 
-const { ActiveItemType, AppOptionsName, AuthOptionsNames, Namespace } = require('./../../../../lib/Constants');
+const { ActiveItemType, AppOptionsName, AuthOptionsNames, CommonOptionsNames, Namespace } = require('./../../../../lib/Constants');
 const { assertions, buildCmd, execCmdWithAssertion, setup, testers } = require('../../../TestsHelper');
 const fixtureApp = require('./../../../fixtures/app.json');
 const fixtureEnv = require('./../../../fixtures/env.json');
@@ -35,6 +35,8 @@ function testEnvDelete(options, flags, envIdentifier, appIdentifier, done) {
     mergedOptions[AppOptionsName.APP] = appIdentifier;
   }
 
+  flags = flags || [];
+  flags.push(CommonOptionsNames.NO_PROMPT);
   testers.execCmdWithIdentifier(baseCmd, mergedOptions, flags, envIdentifier, null, done);
 }
 
@@ -57,7 +59,7 @@ describe(baseCmd, () => {
         [AuthOptionsNames.PASSWORD]: existentUser.password,
         [AppOptionsName.APP]: fixtureApp.name
       };
-      const cmd = buildCmd(baseCmd, [existentEnvName], options, defaultFlags);
+      const cmd = buildCmd(baseCmd, [existentEnvName], options, [CommonOptionsNames.VERBOSE, CommonOptionsNames.NO_PROMPT]);
       execCmdWithAssertion(cmd, null, null, true, true, false, null, (err) => {
         expect(err).to.not.exist;
         done();

--- a/test/integration/commands/flex/flex-clear.test.js
+++ b/test/integration/commands/flex/flex-clear.test.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2017, Kinvey, Inc. All rights reserved.
+ *
+ * This software is licensed to you under the Kinvey terms of service located at
+ * http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+ * software, you hereby accept such terms of service  (and any agreement referenced
+ * therein) and agree that you have read, understand and agree to be bound by such
+ * terms of service and are of legal age to agree to such terms with Kinvey.
+ *
+ * This software contains valuable confidential and proprietary information of
+ * KINVEY, INC and is subject to applicable licensing agreements.
+ * Unauthorized reproduction, transmission or distribution of this file and its
+ * contents is a violation of applicable laws.
+ */
+
+const { CommonOptionsNames, OutputFormat } = require('./../../../../lib/Constants');
+const { assertions, buildCmd, execCmdWithAssertion, setup, testTooManyArgs } = require('../../../TestsHelper');
+
+const baseCmd = 'flex clear';
+
+describe(`${baseCmd}`, () => {
+  before((done) => {
+    setup.clearProjectSetup(null, done);
+  });
+
+  after((done) => {
+    setup.clearProjectSetup(null, done);
+  });
+
+  describe('when project is not set', () => {
+    it('should succeed and output default format', (done) => {
+      const cmd = buildCmd(baseCmd, null, null, [CommonOptionsNames.VERBOSE]);
+
+      execCmdWithAssertion(cmd, null, null, true, true, false, null, (err) => {
+        expect(err).to.not.exist;
+
+        assertions.assertProjectSetup(null, null, (err) => {
+          expect(err).to.not.exist;
+          done();
+        });
+      });
+    });
+
+    it('should succeed and output JSON', (done) => {
+      const cmd = buildCmd(baseCmd, null, { [CommonOptionsNames.OUTPUT]: OutputFormat.JSON }, [CommonOptionsNames.VERBOSE]);
+
+      execCmdWithAssertion(cmd, null, null, true, true, false, null, (err) => {
+        expect(err).to.not.exist;
+
+        assertions.assertProjectSetup(null, null, (err) => {
+          expect(err).to.not.exist;
+          done();
+        });
+      });
+    });
+  });
+
+  describe('when project is set', () => {
+    before((done) => {
+      setup.createProjectSetup('testName', null, done);
+    });
+
+    after((done) => {
+      setup.clearProjectSetup(null, done);
+    });
+
+    it('should succeed', (done) => {
+      const cmd = buildCmd(baseCmd, null, null, [CommonOptionsNames.VERBOSE]);
+
+      execCmdWithAssertion(cmd, null, null, true, true, false, null, (err) => {
+        expect(err).to.not.exist;
+
+        assertions.assertProjectSetup(null, null, (err) => {
+          expect(err).to.not.exist;
+          done();
+        });
+      });
+    });
+
+    it('with too many args should fail', (done) => {
+      testTooManyArgs(baseCmd, 1, done);
+    });
+  });
+});

--- a/test/integration/commands/flex/flex-create.test.js
+++ b/test/integration/commands/flex/flex-create.test.js
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2018, Kinvey, Inc. All rights reserved.
+ *
+ * This software is licensed to you under the Kinvey terms of service located at
+ * http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+ * software, you hereby accept such terms of service  (and any agreement referenced
+ * therein) and agree that you have read, understand and agree to be bound by such
+ * terms of service and are of legal age to agree to such terms with Kinvey.
+ *
+ * This software contains valuable confidential and proprietary information of
+ * KINVEY, INC and is subject to applicable licensing agreements.
+ * Unauthorized reproduction, transmission or distribution of this file and its
+ * contents is a violation of applicable laws.
+ */
+
+const async = require('async');
+
+const { AppOptionsName, AuthOptionsNames, Namespace, OrgOptionsName } = require('./../../../../lib/Constants');
+const fixtureApp = require('./../../../fixtures/app.json');
+const fixtureOrg = require('./../../../fixtures/org.json');
+const fixtureUser = require('./../../../fixtures/user.json');
+const fixtureService = require('./../../../fixtures/internal-flex-service.json');
+const { buildCmd, execCmdWithAssertion, setup, testers } = require('../../../TestsHelper');
+
+const baseCmd = `${Namespace.FLEX} create`;
+const serviceName = fixtureService.name;
+
+function testServiceCreate(options, flags, name, done) {
+  testers.execCmdWithIdentifier(baseCmd, options, flags, name, null, done);
+}
+
+describe(baseCmd, () => {
+  const jsonOptions = testers.getJsonOptions();
+  const defaultFlags = testers.getDefaultFlags();
+  const optionsForApp = { [AppOptionsName.APP]: fixtureApp.id };
+  const optionsForOrg = { [OrgOptionsName.ORG]: fixtureOrg.id };
+  const optionsForSecret = { secret: 123 };
+  const optionsForSecretAndApp = Object.assign({}, optionsForSecret, optionsForApp);
+  const jsonOptionsPlusSecretAndApp = Object.assign(jsonOptions, optionsForSecretAndApp);
+
+  before((done) => {
+    setup.clearGlobalSetup(null, done);
+  });
+
+  after((done) => {
+    setup.clearGlobalSetup(null, done);
+  });
+
+  describe('with active profile', () => {
+    const activeProfile = 'activeProfile';
+
+    before((done) => {
+      setup.setActiveProfile(activeProfile, true, done);
+    });
+
+    after((done) => {
+      setup.clearGlobalSetup(null, done);
+    });
+
+    it('with a name, secret and app should succeed and output default format', (done) => {
+      testServiceCreate(optionsForSecretAndApp, defaultFlags, serviceName, done);
+    });
+
+    it('with a name, secret and app should succeed and output JSON', (done) => {
+      testServiceCreate(jsonOptionsPlusSecretAndApp, null, serviceName, done);
+    });
+
+    it('without a name should fail', (done) => {
+      testServiceCreate(optionsForSecretAndApp, defaultFlags, null, done);
+    });
+
+    it('without a secret should fail', (done) => {
+      testServiceCreate(optionsForApp, null, serviceName, done);
+    });
+
+    it('without an app and org should fail', (done) => {
+      testServiceCreate(optionsForSecret, null, serviceName, done);
+    });
+
+    it('with both app and org should fail', (done) => {
+      const optionsAppOrg = Object.assign({}, optionsForSecretAndApp, optionsForOrg);
+      testServiceCreate(optionsAppOrg, null, serviceName, done);
+    });
+  });
+
+  describe('with one-time session', () => {
+    it('with name, secret and org should succeed', (done) => {
+      const apiOptions = {
+        domainType: 'organizations',
+        domainEntityId: fixtureOrg.id
+      };
+
+      const optionsOrgSecretAndCredentials = Object.assign(
+        {},
+        optionsForSecret,
+        optionsForOrg,
+        {
+          [AuthOptionsNames.EMAIL]: fixtureUser.existent.email,
+          [AuthOptionsNames.PASSWORD]: fixtureUser.existent.password
+        }
+      );
+      const cmd = buildCmd(baseCmd, [serviceName], optionsOrgSecretAndCredentials, defaultFlags);
+      execCmdWithAssertion(cmd, null, apiOptions, true, true, false, null, done);
+    });
+  });
+});

--- a/test/integration/commands/flex/flex-create.test.js
+++ b/test/integration/commands/flex/flex-create.test.js
@@ -69,7 +69,7 @@ describe(baseCmd, () => {
       testServiceCreate(optionsForSecretAndApp, defaultFlags, null, done);
     });
 
-    it('without a secret should fail', (done) => {
+    it('without a secret should succeed', (done) => {
       testServiceCreate(optionsForApp, null, serviceName, done);
     });
 

--- a/test/integration/commands/flex/flex-delete.test.js
+++ b/test/integration/commands/flex/flex-delete.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, Kinvey, Inc. All rights reserved.
+ * Copyright (c) 2018, Kinvey, Inc. All rights reserved.
  *
  * This software is licensed to you under the Kinvey terms of service located at
  * http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -13,72 +13,111 @@
  * contents is a violation of applicable laws.
  */
 
-const { CommonOptionsNames, OutputFormat } = require('./../../../../lib/Constants');
-const { assertions, buildCmd, execCmdWithAssertion, setup, testTooManyArgs } = require('../../../TestsHelper');
+const async = require('async');
+const deepCopy = require('lodash.clonedeep');
+
+const { ActiveItemType, AppOptionsName, AuthOptionsNames, CommonOptionsNames, DomainTypes, Namespace } = require('./../../../../lib/Constants');
+const { assertions, buildCmd, execCmdWithAssertion, setup, testers } = require('../../../TestsHelper');
+const fixtureApp = require('./../../../fixtures/app.json');
+const fixtureUser = require('./../../../fixtures/user.json');
+const fixtureService = require('./../../../fixtures/internal-flex-service.json');
 
 const baseCmd = 'flex delete';
 
-describe(`${baseCmd}`, () => {
+function testServiceDelete(options, flags, serviceId, expectedProjectConfig, done) {
+  testers.execCmdWithIdentifier(baseCmd, options, flags, serviceId, null, (err) => {
+    expect(err).to.not.exist;
+    assertions.assertProjectSetup(expectedProjectConfig, null, done);
+  });
+}
+
+describe(baseCmd, () => {
+  const jsonOptions = testers.getJsonOptions();
+  const defaultFlagsPlusNoPrompt = testers.getDefaultFlags();
+  defaultFlagsPlusNoPrompt.push(CommonOptionsNames.NO_PROMPT);
+
   before((done) => {
-    setup.clearProjectSetup(null, done);
+    setup.clearAllSetup(done);
   });
 
   after((done) => {
-    setup.clearProjectSetup(null, done);
+    setup.clearAllSetup(done);
   });
 
-  describe('when project is not set', () => {
-    it('should succeed and output default format', (done) => {
-      const cmd = buildCmd(baseCmd, null, null, [CommonOptionsNames.VERBOSE]);
-
-      execCmdWithAssertion(cmd, null, null, true, true, false, null, (err) => {
-        expect(err).to.not.exist;
-
-        assertions.assertProjectSetup(null, null, (err) => {
-          expect(err).to.not.exist;
-          done();
-        });
-      });
+  describe('when active profile is set and project config is set', () => {
+    const activeProfile = 'activeProfile';
+    const nonActiveProfile = 'nonActiveProfile';
+    const allProfiles = [activeProfile, nonActiveProfile];
+    const projectConfig = assertions.buildExpectedProject(DomainTypes.APP, fixtureApp.id, fixtureService.id, fixtureService.name);
+    const fullConfig = Object.assign({}, {
+      activeProfile: { flex: deepCopy(projectConfig) },
+      nonActiveProfile: { flex: deepCopy(projectConfig) }
     });
 
-    it('should succeed and output JSON', (done) => {
-      const cmd = buildCmd(baseCmd, null, { [CommonOptionsNames.OUTPUT]: OutputFormat.JSON }, [CommonOptionsNames.VERBOSE]);
+    beforeEach((done) => {
+      async.series([
+        (next) => {
+          setup.createProfiles(allProfiles, next);
+        },
+        (next) => {
+          setup.setActiveProfile(activeProfile, false, next);
+        },
+        (next) => {
+          async.eachSeries(
+            allProfiles,
+            (profile, cb) => {
+              setup.createProjectSetup(profile, projectConfig, cb);
+            },
+            next
+          );
+        }
+      ], done);
+    });
 
-      execCmdWithAssertion(cmd, null, null, true, true, false, null, (err) => {
-        expect(err).to.not.exist;
+    afterEach((done) => {
+      setup.clearAllSetup(done);
+    });
 
-        assertions.assertProjectSetup(null, null, (err) => {
-          expect(err).to.not.exist;
-          done();
-        });
-      });
+    it('without explicit profile and serviceId should succeed', (done) => {
+      const expectedConfig = deepCopy(fullConfig);
+      delete expectedConfig.activeProfile.flex.serviceId;
+      delete expectedConfig.activeProfile.flex.serviceName;
+      testServiceDelete(null, defaultFlagsPlusNoPrompt, null, expectedConfig, done);
+    });
+
+    it('with explicit profile and without serviceId should succeed', (done) => {
+      const expectedConfig = deepCopy(fullConfig);
+      delete expectedConfig.nonActiveProfile.flex.serviceId;
+      delete expectedConfig.nonActiveProfile.flex.serviceName;
+      const options = Object.assign({}, jsonOptions, { [AuthOptionsNames.PROFILE]: nonActiveProfile });
+      testServiceDelete(options, defaultFlagsPlusNoPrompt, null, expectedConfig, done);
+    });
+
+    it('without explicit profile and with non-existent serviceId should fail', (done) => {
+      const nonExistentServiceId = '031784463981495d915c45cdf04790';
+      testServiceDelete(null, defaultFlagsPlusNoPrompt, nonExistentServiceId, fullConfig, done);
+    });
+
+    it('when one-time session and existent serviceId should succeed', (done) => {
+      const serviceId = fixtureService.id;
+      const options = {
+        [AuthOptionsNames.EMAIL]: fixtureUser.existent.email,
+        [AuthOptionsNames.PASSWORD]: fixtureUser.existent.password
+      };
+      // project config should not be altered if one-time session
+      testServiceDelete(options, defaultFlagsPlusNoPrompt, serviceId, fullConfig, done);
     });
   });
 
-  describe('when project is set', () => {
-    before((done) => {
-      setup.createProjectSetup('testName', null, done);
-    });
+  describe('when profiles nor project config are set', () => {
+    it('when one-time session and existent serviceId should succeed', (done) => {
+      const serviceId = fixtureService.id;
+      const options = {
+        [AuthOptionsNames.EMAIL]: fixtureUser.existent.email,
+        [AuthOptionsNames.PASSWORD]: fixtureUser.existent.password
+      };
 
-    after((done) => {
-      setup.clearProjectSetup(null, done);
-    });
-
-    it('should succeed', (done) => {
-      const cmd = buildCmd(baseCmd, null, null, [CommonOptionsNames.VERBOSE]);
-
-      execCmdWithAssertion(cmd, null, null, true, true, false, null, (err) => {
-        expect(err).to.not.exist;
-
-        assertions.assertProjectSetup(null, null, (err) => {
-          expect(err).to.not.exist;
-          done();
-        });
-      });
-    });
-
-    it('with too many args should fail', (done) => {
-      testTooManyArgs(baseCmd, 1, done);
+      testServiceDelete(options, defaultFlagsPlusNoPrompt, serviceId, null, done);
     });
   });
 });

--- a/test/integration/commands/flex/flex-logs.test.js
+++ b/test/integration/commands/flex/flex-logs.test.js
@@ -39,7 +39,7 @@ function testFlexLogs(profileName, optionsForCredentials, serviceId, query, vali
   }
 
   if (serviceId) {
-    cmd = `${cmd} --${FlexOptionsNames.SERVICE_ID} ${serviceId}`;
+    cmd = `${cmd} ${serviceId}`;
   }
 
   const apiOptions = {};

--- a/test/integration/commands/flex/flex-recycle.test.js
+++ b/test/integration/commands/flex/flex-recycle.test.js
@@ -37,11 +37,11 @@ function testFlexRecycle(profileName, options, serviceId, validUser, done) {
   }
 
   const allOptions = buildOptions(profileName, options);
+  const positionalArgs = [];
   if (serviceId) {
-    allOptions[FlexOptionsNames.SERVICE_ID] = serviceId;
+    positionalArgs.push(serviceId);
   }
 
-  const positionalArgs = null;
   const cmd = buildCmd(baseCmd, positionalArgs, allOptions, [CommonOptionsNames.VERBOSE]);
   execCmdWithAssertion(cmd, null, apiOptions, true, true, false, null, done);
 }

--- a/test/integration/commands/flex/flex-status.test.js
+++ b/test/integration/commands/flex/flex-status.test.js
@@ -37,9 +37,10 @@ const replacementObject = {
 
 function testFlexStatus(profileName, options, useServiceId, serviceId, validUser, replacementObject, done) {
   const allOptions = buildOptions(profileName, options);
+  const posArgs = [];
   if (useServiceId) {
     const id = serviceId || defaultServiceId;
-    allOptions[FlexOptionsNames.SERVICE_ID] = id;
+    posArgs.push(id);
   }
 
   const apiOptions = {};
@@ -48,7 +49,7 @@ function testFlexStatus(profileName, options, useServiceId, serviceId, validUser
     apiOptions.existentUser = { email: validUser.email };
   }
 
-  const cmd = buildCmd(baseCmd, null, allOptions, [CommonOptionsNames.VERBOSE]);
+  const cmd = buildCmd(baseCmd, posArgs, allOptions, [CommonOptionsNames.VERBOSE]);
   execCmdWithAssertion(cmd, null, apiOptions, true, true, false, replacementObject, done);
 }
 

--- a/test/mockServer.js
+++ b/test/mockServer.js
@@ -27,6 +27,7 @@ const fixtureCollections = require('./fixtures/collections.json');
 const fixtureCollection = require('./fixtures/collection.json');
 const fixtureOrgs = require('./fixtures/orgs.json');
 const fixtureServices = require('./fixtures/datalinks.json');
+const fixtureInternalFlexService = require('./fixtures/internal-flex-service.json');
 const fixtureJob = require('./fixtures/job.json');
 const fixtureJobs = require('./fixtures/jobs.json');
 const fixtureInternalDataLink = require('./fixtures/kinvey-dlc.json');
@@ -68,6 +69,7 @@ function build(
     serviceStatus = ServiceStatus.ONLINE,
     orgs = fixtureOrgs,
     apps = fixtureApps,
+    service = fixtureInternalFlexService,
     envs = fixtureEnvs,
     colls = fixtureCollections,
     jobType = 'recycleDataLink',
@@ -190,6 +192,18 @@ function build(
     res.send(fixtureServices);
   });
 
+  app.delete(`/${versionPart}/data-links/:id`, (req, res) => {
+    const id = req.params.id;
+    if (id === service.id) {
+      return res.sendStatus(204);
+    }
+
+    res.status(404).send({
+      code: 'DataLinkNotFound',
+      description: 'The specified data link could not be found.'
+    });
+  });
+
   // JOBS
   app.get(`/${versionPart}/jobs/:id`, (req, res) => {
     const id = req.params.id;
@@ -228,6 +242,16 @@ function build(
   // SERVICES BY APP/ORG
   app.get(`/${versionPart}/${domainType}/${domainEntityId}/data-links`, (req, res) => {
     res.send(fixtureServices);
+  });
+
+  app.post(`/${versionPart}/${domainType}/${domainEntityId}/data-links`, (req, res) => {
+    const body = req.body;
+    if (!body.name || body.name !== service.name || body.type !== service.type || !Array.isArray(body.backingServers)
+      || !body.backingServers[0] || !body.backingServers[0].secret) {
+      return res.sendStatus(400);
+    }
+
+    res.status(201).send(service);
   });
 
   // ENVS BY APP


### PR DESCRIPTION
* Add `flex create` command
* Add `flex delete` command to delete internal flex services
* Add `flex clear` command to clear project-specific configuration settings
* Change `serviceId` in the flex namespace to be a positional argument instead of an option
* Add `--no-prompt` flag for delete operations

**Note:** For `flex create` `--secret` is not a required option. It is generated if not provided by user.
