### PR TITLE
CLI-149: Update nyc and snap-shot-it

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,10 +65,10 @@
     "eslint-plugin-import": "2.8.0",
     "express": "4.16.2",
     "mocha": "5.0.4",
-    "nyc": "11.1.0",
+    "nyc": "13.1.0",
     "sinon": "4.1.3",
     "sinon-chai": "2.14.0",
-    "snap-shot-it": "4.0.1",
+    "snap-shot-it": "6.1.9",
     "strip-ansi": "4.0.0",
     "suppose": "0.6.2",
     "test-console": "1.0.0"


### PR DESCRIPTION
Update some dev dependencies. The only one expected to not pass the security check is 'suppose' package ('string' dependency): https://www.npmjs.com/advisories/536. There's no version to update to but at the same time the vulnerability doesn't really concern us. 