### PR TITLE
Add camel case aliases for long options

### DIFF
--- a/__snapshots__/app-create.test.js
+++ b/__snapshots__/app-create.test.js
@@ -1,30 +1,21 @@
-exports['app create with a name and existent org identifier (name) should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using organization: My Team
-[debug] Request:  GET http://localhost:3234/v2/organizations
-[debug] Response: GET http://localhost:3234/v2/organizations 200
-[debug] Request:  POST http://localhost:3234/v2/apps
-[debug] Response: POST http://localhost:3234/v2/apps 201
-Created application: 885f5d307afd4168bebca1a64f815c1e
-
-`
-
-exports['app create with a name should succeed and output default format 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Request:  POST http://localhost:3234/v2/apps
-[debug] Response: POST http://localhost:3234/v2/apps 201
-Created application: 885f5d307afd4168bebca1a64f815c1e
-
-`
-
 exports['app create with a name and existent org identifier (ID) should succeed 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
 [debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
 [debug] Request:  GET http://localhost:3234/v2/organizations/f71b0d5e60684b48b8265e7fa50302b9
 [debug] Response: GET http://localhost:3234/v2/organizations/f71b0d5e60684b48b8265e7fa50302b9 200
+[debug] Request:  POST http://localhost:3234/v2/apps
+[debug] Response: POST http://localhost:3234/v2/apps 201
+Created application: 885f5d307afd4168bebca1a64f815c1e
+
+`
+
+exports['app create with a name and existent org identifier (name) should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using organization: My Team
+[debug] Request:  GET http://localhost:3234/v2/organizations
+[debug] Response: GET http://localhost:3234/v2/organizations 200
 [debug] Request:  POST http://localhost:3234/v2/apps
 [debug] Response: POST http://localhost:3234/v2/apps 201
 Created application: 885f5d307afd4168bebca1a64f815c1e
@@ -44,6 +35,15 @@ exports['app create with a name should succeed and output JSON 1'] = `
 
 `
 
+exports['app create with a name should succeed and output default format 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Request:  POST http://localhost:3234/v2/apps
+[debug] Response: POST http://localhost:3234/v2/apps 201
+Created application: 885f5d307afd4168bebca1a64f815c1e
+
+`
+
 exports['app create without a name should fail 1'] = `
 kinvey app create <name>
 
@@ -53,19 +53,24 @@ Positionals:
   name  App name                                                      [required]
 
 Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --org                     Org ID/name                                 [string]
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --org                                     Org ID/name                 [string]
 
 Not enough non-option arguments: got 0, need at least 1
 

--- a/__snapshots__/coll-create.test.js
+++ b/__snapshots__/coll-create.test.js
@@ -1,3 +1,205 @@
+exports['coll create with profile when active app is not set using existent env id and no app should fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+kinvey coll create <name>
+
+Create a collection
+
+Positionals:
+  name  Collection name                                               [required]
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --env                                     Env ID/name                 [string]
+  --app                                     App ID/name                 [string]
+
+Application is required. Please set active app or use the --app option.
+
+`
+
+exports['coll create with profile when active app is not set using existent env name and existent app id should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
+[debug] Using environment: Development
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[debug] Request:  POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
+[debug] Response: POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
+Created collection: filmsBackedByService
+
+`
+
+exports['coll create with profile when active app is not set using existent env name and existent app name should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: TestApp
+[debug] Request:  GET http://localhost:3234/v2/apps
+[debug] Response: GET http://localhost:3234/v2/apps 200
+[debug] Using environment: Development
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[debug] Request:  POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
+[debug] Response: POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
+Created collection: filmsBackedByService
+
+`
+
+exports['coll create with profile when active app is not set without env and without app should fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+kinvey coll create <name>
+
+Create a collection
+
+Positionals:
+  name  Collection name                                               [required]
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --env                                     Env ID/name                 [string]
+  --app                                     App ID/name                 [string]
+
+Application is required. Please set active app or use the --app option.
+
+`
+
+exports['coll create with profile when active app is set active env is not set using existent env id should succeed and output JSON 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Using environment: kid_Sy4yRNV_M
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
+[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
+[debug] Request:  POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
+[debug] Response: POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
+{
+  "result": {
+    "id": "filmsBackedByService"
+  }
+}
+
+`
+
+exports['coll create with profile when active app is set active env is not set using existent env id should succeed and output default format 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Using environment: kid_Sy4yRNV_M
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
+[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
+[debug] Request:  POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
+[debug] Response: POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
+Created collection: filmsBackedByService
+
+`
+
+exports['coll create with profile when active app is set active env is not set using existent env name and non-existent app name should fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: noSuchApp
+[debug] Request:  GET http://localhost:3234/v2/apps
+[debug] Response: GET http://localhost:3234/v2/apps 200
+[error] NotFound: Could not find application with identifier 'noSuchApp'.
+
+`
+
+exports['coll create with profile when active app is set active env is not set using existent env name should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Using environment: Development
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[debug] Request:  POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
+[debug] Response: POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
+Created collection: filmsBackedByService
+
+`
+
+exports['coll create with profile when active app is set active env is not set using non-existent env id should fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Using environment: kid_JjJJjg2cN
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_JjJJjg2cN
+[debug] Response: GET http://localhost:3234/v2/environments/kid_JjJJjg2cN 404
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[error] NotFound: Could not find environment with identifier 'kid_JjJJjg2cN'.
+
+`
+
+exports['coll create with profile when active app is set active env is not set using non-existent env name should fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Using environment: noSuchName
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[error] NotFound: Could not find environment with identifier 'noSuchName'.
+
+`
+
+exports['coll create with profile when active app is set active env is set with non-existent env id should take precedence and fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Using environment: kid_JjJJjg2cN
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_JjJJjg2cN
+[debug] Response: GET http://localhost:3234/v2/environments/kid_JjJJjg2cN 404
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[error] NotFound: Could not find environment with identifier 'kid_JjJJjg2cN'.
+
+`
+
+exports['coll create with profile when active app is set active env is set without env arg should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using environment: kid_Sy4yRNV_M
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
+[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
+[debug] Request:  POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
+[debug] Response: POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
+Created collection: filmsBackedByService
+
+`
+
 exports['coll create without profile with credentials as options, existent app and env, and coll name should succeed 1'] = `
 [debug] Checking for package updates
 [debug] Logging in user: janeDoe@mail.com
@@ -27,213 +229,26 @@ Positionals:
   name  Collection name                                               [required]
 
 Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --env                     Env ID/name                                 [string]
-  --app                     App ID/name                                 [string]
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --env                                     Env ID/name                 [string]
+  --app                                     App ID/name                 [string]
 
 Not enough non-option arguments: got 0, need at least 1
-
-`
-
-exports['coll create with profile when active app is set active env is set without env arg should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using environment: kid_Sy4yRNV_M
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
-[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
-[debug] Request:  POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
-[debug] Response: POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
-Created collection: filmsBackedByService
-
-`
-
-exports['coll create with profile when active app is set active env is set with non-existent env id should take precedence and fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Using environment: kid_JjJJjg2cN
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_JjJJjg2cN
-[debug] Response: GET http://localhost:3234/v2/environments/kid_JjJJjg2cN 404
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[error] NotFound: Could not find environment with identifier 'kid_JjJJjg2cN'.
-
-`
-
-exports['coll create with profile when active app is set active env is not set using existent env id should succeed and output default format 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Using environment: kid_Sy4yRNV_M
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
-[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
-[debug] Request:  POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
-[debug] Response: POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
-Created collection: filmsBackedByService
-
-`
-
-exports['coll create with profile when active app is set active env is not set using existent env id should succeed and output JSON 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Using environment: kid_Sy4yRNV_M
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
-[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
-[debug] Request:  POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
-[debug] Response: POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
-{
-  "result": {
-    "id": "filmsBackedByService"
-  }
-}
-
-`
-
-exports['coll create with profile when active app is set active env is not set using existent env name should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Using environment: Development
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[debug] Request:  POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
-[debug] Response: POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
-Created collection: filmsBackedByService
-
-`
-
-exports['coll create with profile when active app is set active env is not set using existent env name and non-existent app name should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: noSuchApp
-[debug] Request:  GET http://localhost:3234/v2/apps
-[debug] Response: GET http://localhost:3234/v2/apps 200
-[error] NotFound: Could not find application with identifier 'noSuchApp'.
-
-`
-
-exports['coll create with profile when active app is set active env is not set using non-existent env name should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Using environment: noSuchName
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[error] NotFound: Could not find environment with identifier 'noSuchName'.
-
-`
-
-exports['coll create with profile when active app is set active env is not set using non-existent env id should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Using environment: kid_JjJJjg2cN
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_JjJJjg2cN
-[debug] Response: GET http://localhost:3234/v2/environments/kid_JjJJjg2cN 404
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[error] NotFound: Could not find environment with identifier 'kid_JjJJjg2cN'.
-
-`
-
-exports['coll create with profile when active app is not set using existent env name and existent app name should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: TestApp
-[debug] Request:  GET http://localhost:3234/v2/apps
-[debug] Response: GET http://localhost:3234/v2/apps 200
-[debug] Using environment: Development
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[debug] Request:  POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
-[debug] Response: POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
-Created collection: filmsBackedByService
-
-`
-
-exports['coll create with profile when active app is not set using existent env name and existent app id should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Using environment: Development
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[debug] Request:  POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
-[debug] Response: POST http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
-Created collection: filmsBackedByService
-
-`
-
-exports['coll create with profile when active app is not set using existent env id and no app should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-kinvey coll create <name>
-
-Create a collection
-
-Positionals:
-  name  Collection name                                               [required]
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --env                     Env ID/name                                 [string]
-  --app                     App ID/name                                 [string]
-
-Application is required. Please set active app or use the --app option.
-
-`
-
-exports['coll create with profile when active app is not set without env and without app should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-kinvey coll create <name>
-
-Create a collection
-
-Positionals:
-  name  Collection name                                               [required]
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --env                     Env ID/name                                 [string]
-  --app                     App ID/name                                 [string]
-
-Application is required. Please set active app or use the --app option.
 
 `

--- a/__snapshots__/coll-delete.test.js
+++ b/__snapshots__/coll-delete.test.js
@@ -1,3 +1,209 @@
+exports['coll delete with profile when active app is not set using existent env id and no app should fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+kinvey coll delete <coll>
+
+Delete a collection
+
+Positionals:
+  coll  Collection name                                      [string] [required]
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --env                                     Env ID/name                 [string]
+  --app                                     App ID/name                 [string]
+  --no-prompt, --noPrompt                   Do not prompt
+                                                      [boolean] [default: false]
+
+Application is required. Please set active app or use the --app option.
+
+`
+
+exports['coll delete with profile when active app is not set using existent env name and existent app id should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
+[debug] Using environment: Development
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService
+[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService 204
+Deleted collection: filmsBackedByService
+
+`
+
+exports['coll delete with profile when active app is not set using existent env name and existent app name should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: TestApp
+[debug] Request:  GET http://localhost:3234/v2/apps
+[debug] Response: GET http://localhost:3234/v2/apps 200
+[debug] Using environment: Development
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService
+[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService 204
+Deleted collection: filmsBackedByService
+
+`
+
+exports['coll delete with profile when active app is not set without env and without app should fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+kinvey coll delete <coll>
+
+Delete a collection
+
+Positionals:
+  coll  Collection name                                      [string] [required]
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --env                                     Env ID/name                 [string]
+  --app                                     App ID/name                 [string]
+  --no-prompt, --noPrompt                   Do not prompt
+                                                      [boolean] [default: false]
+
+Application is required. Please set active app or use the --app option.
+
+`
+
+exports['coll delete with profile when active app is set active env is not set using existent env id should succeed and output JSON 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Using environment: kid_Sy4yRNV_M
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
+[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
+[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService
+[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService 204
+{
+  "result": {
+    "id": "filmsBackedByService"
+  }
+}
+
+`
+
+exports['coll delete with profile when active app is set active env is not set using existent env id should succeed and output default format 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Using environment: kid_Sy4yRNV_M
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
+[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
+[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService
+[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService 204
+Deleted collection: filmsBackedByService
+
+`
+
+exports['coll delete with profile when active app is set active env is not set using existent env name and non-existent app name should fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: noSuchApp
+[debug] Request:  GET http://localhost:3234/v2/apps
+[debug] Response: GET http://localhost:3234/v2/apps 200
+[error] NotFound: Could not find application with identifier 'noSuchApp'.
+
+`
+
+exports['coll delete with profile when active app is set active env is not set using existent env name should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Using environment: Development
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService
+[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService 204
+Deleted collection: filmsBackedByService
+
+`
+
+exports['coll delete with profile when active app is set active env is not set using non-existent env id should fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Using environment: kid_JjJJjg2cN
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_JjJJjg2cN
+[debug] Response: GET http://localhost:3234/v2/environments/kid_JjJJjg2cN 404
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[error] NotFound: Could not find environment with identifier 'kid_JjJJjg2cN'.
+
+`
+
+exports['coll delete with profile when active app is set active env is not set using non-existent env name should fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Using environment: noSuchName
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[error] NotFound: Could not find environment with identifier 'noSuchName'.
+
+`
+
+exports['coll delete with profile when active app is set active env is set with non-existent env id should take precedence and fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Using environment: kid_JjJJjg2cN
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_JjJJjg2cN
+[debug] Response: GET http://localhost:3234/v2/environments/kid_JjJJjg2cN 404
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[error] NotFound: Could not find environment with identifier 'kid_JjJJjg2cN'.
+
+`
+
+exports['coll delete with profile when active app is set active env is set without env arg should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using environment: kid_Sy4yRNV_M
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
+[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
+[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService
+[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService 204
+Deleted collection: filmsBackedByService
+
+`
+
 exports['coll delete without profile with credentials as options, existent app and env, and coll name should succeed 1'] = `
 [debug] Checking for package updates
 [debug] Logging in user: janeDoe@mail.com
@@ -27,216 +233,28 @@ Positionals:
   coll  Collection name                                      [string] [required]
 
 Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --env                     Env ID/name                                 [string]
-  --app                     App ID/name                                 [string]
-  --no-prompt               Do not prompt             [boolean] [default: false]
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --env                                     Env ID/name                 [string]
+  --app                                     App ID/name                 [string]
+  --no-prompt, --noPrompt                   Do not prompt
+                                                      [boolean] [default: false]
 
 Not enough non-option arguments: got 0, need at least 1
-
-`
-
-exports['coll delete with profile when active app is set active env is set without env arg should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using environment: kid_Sy4yRNV_M
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
-[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
-[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService
-[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService 204
-Deleted collection: filmsBackedByService
-
-`
-
-exports['coll delete with profile when active app is set active env is set with non-existent env id should take precedence and fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Using environment: kid_JjJJjg2cN
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_JjJJjg2cN
-[debug] Response: GET http://localhost:3234/v2/environments/kid_JjJJjg2cN 404
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[error] NotFound: Could not find environment with identifier 'kid_JjJJjg2cN'.
-
-`
-
-exports['coll delete with profile when active app is set active env is not set using existent env id should succeed and output default format 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Using environment: kid_Sy4yRNV_M
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
-[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
-[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService
-[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService 204
-Deleted collection: filmsBackedByService
-
-`
-
-exports['coll delete with profile when active app is set active env is not set using existent env id should succeed and output JSON 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Using environment: kid_Sy4yRNV_M
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
-[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
-[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService
-[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService 204
-{
-  "result": {
-    "id": "filmsBackedByService"
-  }
-}
-
-`
-
-exports['coll delete with profile when active app is set active env is not set using existent env name should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Using environment: Development
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService
-[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService 204
-Deleted collection: filmsBackedByService
-
-`
-
-exports['coll delete with profile when active app is set active env is not set using existent env name and non-existent app name should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: noSuchApp
-[debug] Request:  GET http://localhost:3234/v2/apps
-[debug] Response: GET http://localhost:3234/v2/apps 200
-[error] NotFound: Could not find application with identifier 'noSuchApp'.
-
-`
-
-exports['coll delete with profile when active app is set active env is not set using non-existent env name should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Using environment: noSuchName
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[error] NotFound: Could not find environment with identifier 'noSuchName'.
-
-`
-
-exports['coll delete with profile when active app is set active env is not set using non-existent env id should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Using environment: kid_JjJJjg2cN
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_JjJJjg2cN
-[debug] Response: GET http://localhost:3234/v2/environments/kid_JjJJjg2cN 404
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[error] NotFound: Could not find environment with identifier 'kid_JjJJjg2cN'.
-
-`
-
-exports['coll delete with profile when active app is not set using existent env name and existent app name should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: TestApp
-[debug] Request:  GET http://localhost:3234/v2/apps
-[debug] Response: GET http://localhost:3234/v2/apps 200
-[debug] Using environment: Development
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService
-[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService 204
-Deleted collection: filmsBackedByService
-
-`
-
-exports['coll delete with profile when active app is not set using existent env name and existent app id should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Using environment: Development
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService
-[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections/filmsBackedByService 204
-Deleted collection: filmsBackedByService
-
-`
-
-exports['coll delete with profile when active app is not set using existent env id and no app should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-kinvey coll delete <coll>
-
-Delete a collection
-
-Positionals:
-  coll  Collection name                                      [string] [required]
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --env                     Env ID/name                                 [string]
-  --app                     App ID/name                                 [string]
-  --no-prompt               Do not prompt             [boolean] [default: false]
-
-Application is required. Please set active app or use the --app option.
-
-`
-
-exports['coll delete with profile when active app is not set without env and without app should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-kinvey coll delete <coll>
-
-Delete a collection
-
-Positionals:
-  coll  Collection name                                      [string] [required]
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --env                     Env ID/name                                 [string]
-  --app                     App ID/name                                 [string]
-  --no-prompt               Do not prompt             [boolean] [default: false]
-
-Application is required. Please set active app or use the --app option.
 
 `

--- a/__snapshots__/coll-list.test.js
+++ b/__snapshots__/coll-list.test.js
@@ -1,8 +1,62 @@
-exports['coll list without profile with credentials as options, existent app and env should succeed 1'] = `
+exports['coll list with profile when active app is not set using existent env id and no app should fail 1'] = `
 [debug] Checking for package updates
-[debug] Logging in user: janeDoe@mail.com
-[debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 200
+[debug] Using profile 'activeProfile'
+kinvey coll list
+
+List collections per environment
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --env                                     Env ID/name                 [string]
+  --app                                     App ID/name                 [string]
+
+Application is required. Please set active app or use the --app option.
+
+`
+
+exports['coll list with profile when active app is not set using existent env name and existent app id should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
+[debug] Using environment: Development
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
+[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
+Count: 4
+
+name                  type    
+--------------------  --------
+BlueC                 internal
+filmsBackedByService  external
+SimpleColl            internal
+user                  internal
+
+
+
+`
+
+exports['coll list with profile when active app is not set using existent env name and existent app name should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
 [debug] Using application: TestApp
 [debug] Request:  GET http://localhost:3234/v2/apps
 [debug] Response: GET http://localhost:3234/v2/apps 200
@@ -11,9 +65,6 @@ exports['coll list without profile with credentials as options, existent app and
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
 [debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
 [debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
-[debug] Request:  DELETE http://localhost:3234/session
-[debug] Response: DELETE http://localhost:3234/session 204
-[debug] Logged out current user.
 Count: 4
 
 name                  type    
@@ -27,59 +78,35 @@ user                  internal
 
 `
 
-exports['coll list with profile when active app is set active env is set without env arg should succeed 1'] = `
+exports['coll list with profile when active app is not set without env and without app should fail 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
-[debug] Using environment: kid_Sy4yRNV_M
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
-[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
-[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
-Count: 4
+kinvey coll list
 
-name                  type    
---------------------  --------
-BlueC                 internal
-filmsBackedByService  external
-SimpleColl            internal
-user                  internal
+List collections per environment
 
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --env                                     Env ID/name                 [string]
+  --app                                     App ID/name                 [string]
 
-
-`
-
-exports['coll list with profile when active app is set active env is set with non-existent env id should take precedence and fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Using environment: kid_JjJJjg2cN
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_JjJJjg2cN
-[debug] Response: GET http://localhost:3234/v2/environments/kid_JjJJjg2cN 404
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[error] NotFound: Could not find environment with identifier 'kid_JjJJjg2cN'.
-
-`
-
-exports['coll list with profile when active app is set active env is not set using existent env id should succeed and output default format 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Using environment: kid_Sy4yRNV_M
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
-[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
-[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
-Count: 4
-
-name                  type    
---------------------  --------
-BlueC                 internal
-filmsBackedByService  external
-SimpleColl            internal
-user                  internal
-
-
+Application is required. Please set active app or use the --app option.
 
 `
 
@@ -153,13 +180,13 @@ exports['coll list with profile when active app is set active env is not set usi
 
 `
 
-exports['coll list with profile when active app is set active env is not set using existent env name should succeed 1'] = `
+exports['coll list with profile when active app is set active env is not set using existent env id should succeed and output default format 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
 [debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Using environment: Development
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[debug] Using environment: kid_Sy4yRNV_M
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
+[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
 [debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
 [debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
 Count: 4
@@ -185,14 +212,25 @@ exports['coll list with profile when active app is set active env is not set usi
 
 `
 
-exports['coll list with profile when active app is set active env is not set using non-existent env name should fail 1'] = `
+exports['coll list with profile when active app is set active env is not set using existent env name should succeed 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
 [debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Using environment: noSuchName
+[debug] Using environment: Development
 [debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[error] NotFound: Could not find environment with identifier 'noSuchName'.
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
+[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
+Count: 4
+
+name                  type    
+--------------------  --------
+BlueC                 internal
+filmsBackedByService  external
+SimpleColl            internal
+user                  internal
+
+
 
 `
 
@@ -209,9 +247,56 @@ exports['coll list with profile when active app is set active env is not set usi
 
 `
 
-exports['coll list with profile when active app is not set using existent env name and existent app name should succeed 1'] = `
+exports['coll list with profile when active app is set active env is not set using non-existent env name should fail 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Using environment: noSuchName
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[error] NotFound: Could not find environment with identifier 'noSuchName'.
+
+`
+
+exports['coll list with profile when active app is set active env is set with non-existent env id should take precedence and fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Using environment: kid_JjJJjg2cN
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_JjJJjg2cN
+[debug] Response: GET http://localhost:3234/v2/environments/kid_JjJJjg2cN 404
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[error] NotFound: Could not find environment with identifier 'kid_JjJJjg2cN'.
+
+`
+
+exports['coll list with profile when active app is set active env is set without env arg should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using environment: kid_Sy4yRNV_M
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
+[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
+[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
+Count: 4
+
+name                  type    
+--------------------  --------
+BlueC                 internal
+filmsBackedByService  external
+SimpleColl            internal
+user                  internal
+
+
+
+`
+
+exports['coll list without profile with credentials as options, existent app and env should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Logging in user: janeDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 200
 [debug] Using application: TestApp
 [debug] Request:  GET http://localhost:3234/v2/apps
 [debug] Response: GET http://localhost:3234/v2/apps 200
@@ -220,6 +305,9 @@ exports['coll list with profile when active app is not set using existent env na
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
 [debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
 [debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
+[debug] Request:  DELETE http://localhost:3234/session
+[debug] Response: DELETE http://localhost:3234/session 204
+[debug] Logged out current user.
 Count: 4
 
 name                  type    
@@ -230,83 +318,5 @@ SimpleColl            internal
 user                  internal
 
 
-
-`
-
-exports['coll list with profile when active app is not set using existent env name and existent app id should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Using environment: Development
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections
-[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M/collections 200
-Count: 4
-
-name                  type    
---------------------  --------
-BlueC                 internal
-filmsBackedByService  external
-SimpleColl            internal
-user                  internal
-
-
-
-`
-
-exports['coll list with profile when active app is not set using existent env id and no app should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-kinvey coll list
-
-List collections per environment
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --env                     Env ID/name                                 [string]
-  --app                     App ID/name                                 [string]
-
-Application is required. Please set active app or use the --app option.
-
-`
-
-exports['coll list with profile when active app is not set without env and without app should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-kinvey coll list
-
-List collections per environment
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --env                     Env ID/name                                 [string]
-  --app                     App ID/name                                 [string]
-
-Application is required. Please set active app or use the --app option.
 
 `

--- a/__snapshots__/common.test.js
+++ b/__snapshots__/common.test.js
@@ -1,30 +1,3 @@
-exports['common flags and options with unsupported hyphenated option should fail 1'] = `
-kinvey profile show [name]
-
-View detailed info for a profile. If no profile is specified, the active profile
-is used.
-
-Positionals:
-  name  Profile name
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-
-Unknown argument: test-option
-
-`
-
 exports['common flags and options with unsupported hyphenated flag should fail 1'] = `
 kinvey profile show [name]
 
@@ -35,20 +8,155 @@ Positionals:
   name  Profile name
 
 Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
 
 Unknown argument: no-prompt
+
+`
+
+exports['common flags and options with unsupported hyphenated option should fail 1'] = `
+kinvey profile show [name]
+
+View detailed info for a profile. If no profile is specified, the active profile
+is used.
+
+Positionals:
+  name  Profile name
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+
+Unknown argument: test-option
+
+`
+
+exports['common incomplete commands namespace (app) only should show help 1'] = `
+kinvey app
+
+Manage applications. Run 'kinvey app -h for details.
+
+Commands:
+  kinvey app create <name>  Create an application
+  kinvey app list           List applications
+  kinvey app show           Show detailed info for a specified app or for the
+                            active one
+  kinvey app use <app>      Set the active application
+  kinvey app delete         Delete a specified app or the active one
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+
+
+`
+
+exports['common incomplete commands namespace (appenv) only should show help 1'] = `
+kinvey appenv <command> [args] [options]
+
+Commands:
+  kinvey appenv create <name>  Create an environment
+  kinvey appenv list           List environments per app
+  kinvey appenv show           Show detailed info for a specified environment or
+                               for the active one
+  kinvey appenv use <env>      Set the active environment
+  kinvey appenv delete         Delete a specified environment or the active one
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+
+
+`
+
+exports['common incomplete commands namespace (coll) only should show help 1'] = `
+kinvey coll <command> [args] [options]
+
+Commands:
+  kinvey coll create <name>  Create a collection
+  kinvey coll list           List collections per environment
+  kinvey coll delete <coll>  Delete a collection
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+
 
 `
 
@@ -71,101 +179,23 @@ Commands:
   kinvey flex clear          Clear project settings
 
 Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-
-
-`
-
-exports['common incomplete commands namespace (app) only should show help 1'] = `
-kinvey app
-
-Manage applications. Run 'kinvey app -h for details.
-
-Commands:
-  kinvey app create <name>  Create an application
-  kinvey app list           List applications
-  kinvey app show           Show detailed info for a specified app or for the
-                            active one
-  kinvey app use <app>      Set the active application
-  kinvey app delete         Delete a specified app or the active one
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-
-
-`
-
-exports['common incomplete commands namespace (coll) only should show help 1'] = `
-kinvey coll <command> [args] [options]
-
-Commands:
-  kinvey coll create <name>  Create a collection
-  kinvey coll list           List collections per environment
-  kinvey coll delete <coll>  Delete a collection
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-
-
-`
-
-exports['common incomplete commands namespace (appenv) only should show help 1'] = `
-kinvey appenv <command> [args] [options]
-
-Commands:
-  kinvey appenv create <name>  Create an environment
-  kinvey appenv list           List environments per app
-  kinvey appenv show           Show detailed info for a specified environment or
-                               for the active one
-  kinvey appenv use <env>      Set the active environment
-  kinvey appenv delete         Delete a specified environment or the active one
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
 
 
 `
@@ -182,18 +212,23 @@ Commands:
   kinvey org use <org>  Set the active organization
 
 Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
 
 
 `
@@ -214,18 +249,23 @@ Commands:
                                 specified, the active profile is used.
 
 Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
 
 
 `

--- a/__snapshots__/env-create.test.js
+++ b/__snapshots__/env-create.test.js
@@ -1,15 +1,3 @@
-exports['appenv create when active app is set with a name should succeed and output default format 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Request:  POST http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: POST http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-Created environment: kid_Sy4yRNV_M
-
-`
-
 exports['appenv create when active app is set with a name should succeed and output JSON 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
@@ -26,30 +14,15 @@ exports['appenv create when active app is set with a name should succeed and out
 
 `
 
-exports['appenv create when active app is set without a name should fail 1'] = `
-kinvey appenv create <name>
-
-Create an environment
-
-Positionals:
-  name  Env name                                                      [required]
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --app                     App ID/name                                 [string]
-
-Not enough non-option arguments: got 0, need at least 1
+exports['appenv create when active app is set with a name should succeed and output default format 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
+[debug] Request:  POST http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: POST http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+Created environment: kid_Sy4yRNV_M
 
 `
 
@@ -72,6 +45,38 @@ exports['appenv create when active app is set with non-existent app name should 
 [debug] Request:  GET http://localhost:3234/v2/apps
 [debug] Response: GET http://localhost:3234/v2/apps 200
 [error] NotFound: Could not find application with identifier 'iJustDoNotExist'.
+
+`
+
+exports['appenv create when active app is set without a name should fail 1'] = `
+kinvey appenv create <name>
+
+Create an environment
+
+Positionals:
+  name  Env name                                                      [required]
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --app                                     App ID/name                 [string]
+
+Not enough non-option arguments: got 0, need at least 1
 
 `
 
@@ -102,19 +107,24 @@ Positionals:
   name  Env name                                                      [required]
 
 Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --app                     App ID/name                                 [string]
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --app                                     App ID/name                 [string]
 
 Application is required. Please set active app or use the --app option.
 

--- a/__snapshots__/env-delete.test.js
+++ b/__snapshots__/env-delete.test.js
@@ -1,8 +1,55 @@
-exports['appenv delete without profile with credentials as options, existent app and env should succeed 1'] = `
+exports['appenv delete with profile when active app is not set using existent env id and no app should fail 1'] = `
 [debug] Checking for package updates
-[debug] Logging in user: janeDoe@mail.com
-[debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 200
+[debug] Using profile 'activeProfile'
+kinvey appenv delete
+
+Delete a specified environment or the active one
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --env                                     Env ID/name                 [string]
+  --app                                     App ID/name                 [string]
+  --no-prompt, --noPrompt                   Do not prompt
+                                                      [boolean] [default: false]
+
+Application is required. Please set active app or use the --app option.
+
+`
+
+exports['appenv delete with profile when active app is not set using existent env name and existent app id should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
+[debug] Using environment: Development
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M
+[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M 204
+Deleted environment: kid_Sy4yRNV_M
+
+`
+
+exports['appenv delete with profile when active app is not set using existent env name and existent app name should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
 [debug] Using application: TestApp
 [debug] Request:  GET http://localhost:3234/v2/apps
 [debug] Response: GET http://localhost:3234/v2/apps 200
@@ -11,54 +58,41 @@ exports['appenv delete without profile with credentials as options, existent app
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
 [debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M
 [debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M 204
-[debug] Request:  DELETE http://localhost:3234/session
-[debug] Response: DELETE http://localhost:3234/session 204
-[debug] Logged out current user.
 Deleted environment: kid_Sy4yRNV_M
 
 `
 
-exports['appenv delete with profile when active app is set active env is set without env arg should succeed 1'] = `
+exports['appenv delete with profile when active app is not set without env and without app should fail 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
-[debug] Using environment: kid_Sy4yRNV_M
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
-[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
-[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M
-[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M 204
-[debug] Writing contents to file globalSetupPath
-[debug] Removed active env: kid_Sy4yRNV_M.
-Deleted environment: kid_Sy4yRNV_M
+kinvey appenv delete
 
-`
+Delete a specified environment or the active one
 
-exports['appenv delete with profile when active app is set active env is set with non-existent env id should take precedence and fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Using environment: kid_JjJJjg2cN
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_JjJJjg2cN
-[debug] Response: GET http://localhost:3234/v2/environments/kid_JjJJjg2cN 404
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[error] NotFound: Could not find environment with identifier 'kid_JjJJjg2cN'.
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --env                                     Env ID/name                 [string]
+  --app                                     App ID/name                 [string]
+  --no-prompt, --noPrompt                   Do not prompt
+                                                      [boolean] [default: false]
 
-`
-
-exports['appenv delete with profile when active app is set active env is not set using existent env id should succeed and output default format 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Using environment: kid_Sy4yRNV_M
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
-[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
-[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M
-[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M 204
-Deleted environment: kid_Sy4yRNV_M
+Application is required. Please set active app or use the --app option.
 
 `
 
@@ -81,15 +115,15 @@ exports['appenv delete with profile when active app is set active env is not set
 
 `
 
-exports['appenv delete with profile when active app is set active env is not set using existent env name should succeed 1'] = `
+exports['appenv delete with profile when active app is set active env is not set using existent env id should succeed and output default format 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
 [debug] Using application: 885f5d307afd4168bebca1a64f815c1e
 [debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Using environment: Development
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[debug] Using environment: kid_Sy4yRNV_M
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
+[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
 [debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M
 [debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M 204
 Deleted environment: kid_Sy4yRNV_M
@@ -106,16 +140,18 @@ exports['appenv delete with profile when active app is set active env is not set
 
 `
 
-exports['appenv delete with profile when active app is set active env is not set using non-existent env name should fail 1'] = `
+exports['appenv delete with profile when active app is set active env is not set using existent env name should succeed 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
 [debug] Using application: 885f5d307afd4168bebca1a64f815c1e
 [debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Using environment: noSuchName
+[debug] Using environment: Development
 [debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[error] NotFound: Could not find environment with identifier 'noSuchName'.
+[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M
+[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M 204
+Deleted environment: kid_Sy4yRNV_M
 
 `
 
@@ -134,9 +170,53 @@ exports['appenv delete with profile when active app is set active env is not set
 
 `
 
-exports['appenv delete with profile when active app is not set using existent env name and existent app name should succeed 1'] = `
+exports['appenv delete with profile when active app is set active env is not set using non-existent env name should fail 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
+[debug] Using environment: noSuchName
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[error] NotFound: Could not find environment with identifier 'noSuchName'.
+
+`
+
+exports['appenv delete with profile when active app is set active env is set with non-existent env id should take precedence and fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
+[debug] Using environment: kid_JjJJjg2cN
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_JjJJjg2cN
+[debug] Response: GET http://localhost:3234/v2/environments/kid_JjJJjg2cN 404
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[error] NotFound: Could not find environment with identifier 'kid_JjJJjg2cN'.
+
+`
+
+exports['appenv delete with profile when active app is set active env is set without env arg should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using environment: kid_Sy4yRNV_M
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
+[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
+[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M
+[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M 204
+[debug] Writing contents to file globalSetupPath
+[debug] Removed active env: kid_Sy4yRNV_M.
+Deleted environment: kid_Sy4yRNV_M
+
+`
+
+exports['appenv delete without profile with credentials as options, existent app and env should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Logging in user: janeDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 200
 [debug] Using application: TestApp
 [debug] Request:  GET http://localhost:3234/v2/apps
 [debug] Response: GET http://localhost:3234/v2/apps 200
@@ -145,77 +225,9 @@ exports['appenv delete with profile when active app is not set using existent en
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
 [debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M
 [debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M 204
+[debug] Request:  DELETE http://localhost:3234/session
+[debug] Response: DELETE http://localhost:3234/session 204
+[debug] Logged out current user.
 Deleted environment: kid_Sy4yRNV_M
-
-`
-
-exports['appenv delete with profile when active app is not set using existent env name and existent app id should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Using environment: Development
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[debug] Request:  DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M
-[debug] Response: DELETE http://localhost:3234/v2/environments/kid_Sy4yRNV_M 204
-Deleted environment: kid_Sy4yRNV_M
-
-`
-
-exports['appenv delete with profile when active app is not set using existent env id and no app should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-kinvey appenv delete
-
-Delete a specified environment or the active one
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --env                     Env ID/name                                 [string]
-  --app                     App ID/name                                 [string]
-  --no-prompt               Do not prompt             [boolean] [default: false]
-
-Application is required. Please set active app or use the --app option.
-
-`
-
-exports['appenv delete with profile when active app is not set without env and without app should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-kinvey appenv delete
-
-Delete a specified environment or the active one
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --env                     Env ID/name                                 [string]
-  --app                     App ID/name                                 [string]
-  --no-prompt               Do not prompt             [boolean] [default: false]
-
-Application is required. Please set active app or use the --app option.
 
 `

--- a/__snapshots__/env-list.test.js
+++ b/__snapshots__/env-list.test.js
@@ -1,22 +1,3 @@
-exports['appenv list when active app is set should output default format 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-Count: 2
-
-id             name       
--------------  -----------
-kid_Sy4yRNV_M  Development
-kid_Ty4yRNV_O  Staging    
-
-
-
-`
-
 exports['appenv list when active app is set should output JSON 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
@@ -49,6 +30,25 @@ exports['appenv list when active app is set should output JSON 1'] = `
     }
   ]
 }
+
+`
+
+exports['appenv list when active app is set should output default format 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+Count: 2
+
+id             name       
+-------------  -----------
+kid_Sy4yRNV_M  Development
+kid_Ty4yRNV_O  Staging    
+
+
 
 `
 
@@ -105,19 +105,24 @@ kinvey appenv list
 List environments per app
 
 Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --app                     App ID/name                                 [string]
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --app                                     App ID/name                 [string]
 
 Application is required. Please set active app or use the --app option.
 

--- a/__snapshots__/env-show.test.js
+++ b/__snapshots__/env-show.test.js
@@ -1,17 +1,62 @@
-exports['appenv show without profile with credentials as options, existent app and env should succeed 1'] = `
+exports['appenv show with profile when active app is not set using existent env id and no app should fail 1'] = `
 [debug] Checking for package updates
-[debug] Logging in user: janeDoe@mail.com
-[debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 200
+[debug] Using profile 'activeProfile'
+kinvey appenv show
+
+Show detailed info for a specified environment or for the active one
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --env                                     Env ID/name                 [string]
+  --app                                     App ID/name                 [string]
+
+Application is required. Please set active app or use the --app option.
+
+`
+
+exports['appenv show with profile when active app is not set using existent env name and existent app id should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
+[debug] Using environment: Development
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+key        value                           
+---------  --------------------------------
+id         kid_Sy4yRNV_M                   
+name       Development                     
+appSecret  f006f2fda0fd4fc7b154e12a15ae81fe
+
+
+`
+
+exports['appenv show with profile when active app is not set using existent env name and existent app name should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
 [debug] Using application: TestApp
 [debug] Request:  GET http://localhost:3234/v2/apps
 [debug] Response: GET http://localhost:3234/v2/apps 200
 [debug] Using environment: Development
 [debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[debug] Request:  DELETE http://localhost:3234/session
-[debug] Response: DELETE http://localhost:3234/session 204
-[debug] Logged out current user.
 key        value                           
 ---------  --------------------------------
 id         kid_Sy4yRNV_M                   
@@ -21,51 +66,35 @@ appSecret  f006f2fda0fd4fc7b154e12a15ae81fe
 
 `
 
-exports['appenv show with profile when active app is set active env is set without env arg should succeed 1'] = `
+exports['appenv show with profile when active app is not set without env and without app should fail 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
-[debug] Using environment: kid_Sy4yRNV_M
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
-[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
-key        value                           
----------  --------------------------------
-id         kid_Sy4yRNV_M                   
-name       Development                     
-appSecret  f006f2fda0fd4fc7b154e12a15ae81fe
+kinvey appenv show
 
+Show detailed info for a specified environment or for the active one
 
-`
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --env                                     Env ID/name                 [string]
+  --app                                     App ID/name                 [string]
 
-exports['appenv show with profile when active app is set active env is set with non-existent env id should take precedence and fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Using environment: kid_JjJJjg2cN
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_JjJJjg2cN
-[debug] Response: GET http://localhost:3234/v2/environments/kid_JjJJjg2cN 404
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[error] NotFound: Could not find environment with identifier 'kid_JjJJjg2cN'.
-
-`
-
-exports['appenv show with profile when active app is set active env is not set using existent env id should succeed and output default format 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Using environment: kid_Sy4yRNV_M
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
-[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
-key        value                           
----------  --------------------------------
-id         kid_Sy4yRNV_M                   
-name       Development                     
-appSecret  f006f2fda0fd4fc7b154e12a15ae81fe
-
+Application is required. Please set active app or use the --app option.
 
 `
 
@@ -93,15 +122,15 @@ exports['appenv show with profile when active app is set active env is not set u
 
 `
 
-exports['appenv show with profile when active app is set active env is not set using existent env name should succeed 1'] = `
+exports['appenv show with profile when active app is set active env is not set using existent env id should succeed and output default format 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
 [debug] Using application: 885f5d307afd4168bebca1a64f815c1e
 [debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Using environment: Development
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[debug] Using environment: kid_Sy4yRNV_M
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
+[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
 key        value                           
 ---------  --------------------------------
 id         kid_Sy4yRNV_M                   
@@ -121,16 +150,21 @@ exports['appenv show with profile when active app is set active env is not set u
 
 `
 
-exports['appenv show with profile when active app is set active env is not set using non-existent env name should fail 1'] = `
+exports['appenv show with profile when active app is set active env is not set using existent env name should succeed 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
 [debug] Using application: 885f5d307afd4168bebca1a64f815c1e
 [debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Using environment: noSuchName
+[debug] Using environment: Development
 [debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[error] NotFound: Could not find environment with identifier 'noSuchName'.
+key        value                           
+---------  --------------------------------
+id         kid_Sy4yRNV_M                   
+name       Development                     
+appSecret  f006f2fda0fd4fc7b154e12a15ae81fe
+
 
 `
 
@@ -149,92 +183,68 @@ exports['appenv show with profile when active app is set active env is not set u
 
 `
 
-exports['appenv show with profile when active app is not set using existent env name and existent app name should succeed 1'] = `
+exports['appenv show with profile when active app is set active env is not set using non-existent env name should fail 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
+[debug] Using environment: noSuchName
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[error] NotFound: Could not find environment with identifier 'noSuchName'.
+
+`
+
+exports['appenv show with profile when active app is set active env is set with non-existent env id should take precedence and fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
+[debug] Using environment: kid_JjJJjg2cN
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_JjJJjg2cN
+[debug] Response: GET http://localhost:3234/v2/environments/kid_JjJJjg2cN 404
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[error] NotFound: Could not find environment with identifier 'kid_JjJJjg2cN'.
+
+`
+
+exports['appenv show with profile when active app is set active env is set without env arg should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using environment: kid_Sy4yRNV_M
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
+[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
+key        value                           
+---------  --------------------------------
+id         kid_Sy4yRNV_M                   
+name       Development                     
+appSecret  f006f2fda0fd4fc7b154e12a15ae81fe
+
+
+`
+
+exports['appenv show without profile with credentials as options, existent app and env should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Logging in user: janeDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 200
 [debug] Using application: TestApp
 [debug] Request:  GET http://localhost:3234/v2/apps
 [debug] Response: GET http://localhost:3234/v2/apps 200
 [debug] Using environment: Development
 [debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[debug] Request:  DELETE http://localhost:3234/session
+[debug] Response: DELETE http://localhost:3234/session 204
+[debug] Logged out current user.
 key        value                           
 ---------  --------------------------------
 id         kid_Sy4yRNV_M                   
 name       Development                     
 appSecret  f006f2fda0fd4fc7b154e12a15ae81fe
 
-
-`
-
-exports['appenv show with profile when active app is not set using existent env name and existent app id should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Using environment: Development
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-key        value                           
----------  --------------------------------
-id         kid_Sy4yRNV_M                   
-name       Development                     
-appSecret  f006f2fda0fd4fc7b154e12a15ae81fe
-
-
-`
-
-exports['appenv show with profile when active app is not set using existent env id and no app should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-kinvey appenv show
-
-Show detailed info for a specified environment or for the active one
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --env                     Env ID/name                                 [string]
-  --app                     App ID/name                                 [string]
-
-Application is required. Please set active app or use the --app option.
-
-`
-
-exports['appenv show with profile when active app is not set without env and without app should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-kinvey appenv show
-
-Show detailed info for a specified environment or for the active one
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --env                     Env ID/name                                 [string]
-  --app                     App ID/name                                 [string]
-
-Application is required. Please set active app or use the --app option.
 
 `

--- a/__snapshots__/env-use.test.js
+++ b/__snapshots__/env-use.test.js
@@ -1,20 +1,94 @@
-exports['appenv use without profile with credentials as options should fail 1'] = `
+exports['appenv use with profile when active app is not set using existent env id and no app should fail 1'] = `
 [debug] Checking for package updates
-[error] ProfileRequired: Profile is required. Please set active profile or use the --profile option.
+[debug] Using profile 'activeProfile'
+kinvey appenv use <env>
+
+Set the active environment
+
+Positionals:
+  env  Env ID/name                                           [string] [required]
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --app                                     App ID/name                 [string]
+
+Application is required. Please set active app or use the --app option.
 
 `
 
-exports['appenv use with profile when active app is set using existent env id should succeed and output default format 1'] = `
+exports['appenv use with profile when active app is not set using existent env name and existent app id should succeed 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
 [debug] Using application: 885f5d307afd4168bebca1a64f815c1e
 [debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Using environment: kid_Sy4yRNV_M
-[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
-[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
+[debug] Using environment: Development
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
 [debug] Writing contents to file globalSetupPath
 Active environment: kid_Sy4yRNV_M
+
+`
+
+exports['appenv use with profile when active app is not set using existent env name and existent app name should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: TestApp
+[debug] Request:  GET http://localhost:3234/v2/apps
+[debug] Response: GET http://localhost:3234/v2/apps 200
+[debug] Using environment: Development
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[debug] Writing contents to file globalSetupPath
+Active environment: kid_Sy4yRNV_M
+
+`
+
+exports['appenv use with profile when active app is not set without env and without app should fail 1'] = `
+kinvey appenv use <env>
+
+Set the active environment
+
+Positionals:
+  env  Env ID/name                                           [string] [required]
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --app                                     App ID/name                 [string]
+
+Not enough non-option arguments: got 0, need at least 1
 
 `
 
@@ -36,15 +110,15 @@ exports['appenv use with profile when active app is set using existent env id sh
 
 `
 
-exports['appenv use with profile when active app is set using existent env name should succeed 1'] = `
+exports['appenv use with profile when active app is set using existent env id should succeed and output default format 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
 [debug] Using application: 885f5d307afd4168bebca1a64f815c1e
 [debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Using environment: Development
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
+[debug] Using environment: kid_Sy4yRNV_M
+[debug] Request:  GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M
+[debug] Response: GET http://localhost:3234/v2/environments/kid_Sy4yRNV_M 200
 [debug] Writing contents to file globalSetupPath
 Active environment: kid_Sy4yRNV_M
 
@@ -60,16 +134,17 @@ exports['appenv use with profile when active app is set using existent env name 
 
 `
 
-exports['appenv use with profile when active app is set using non-existent env name should fail 1'] = `
+exports['appenv use with profile when active app is set using existent env name should succeed 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
 [debug] Using application: 885f5d307afd4168bebca1a64f815c1e
 [debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Using environment: noSuchName
+[debug] Using environment: Development
 [debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[error] NotFound: Could not find environment with identifier 'noSuchName'.
+[debug] Writing contents to file globalSetupPath
+Active environment: kid_Sy4yRNV_M
 
 `
 
@@ -88,86 +163,21 @@ exports['appenv use with profile when active app is set using non-existent env i
 
 `
 
-exports['appenv use with profile when active app is not set using existent env name and existent app name should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: TestApp
-[debug] Request:  GET http://localhost:3234/v2/apps
-[debug] Response: GET http://localhost:3234/v2/apps 200
-[debug] Using environment: Development
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[debug] Writing contents to file globalSetupPath
-Active environment: kid_Sy4yRNV_M
-
-`
-
-exports['appenv use with profile when active app is not set using existent env name and existent app id should succeed 1'] = `
+exports['appenv use with profile when active app is set using non-existent env name should fail 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
 [debug] Using application: 885f5d307afd4168bebca1a64f815c1e
 [debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Using environment: Development
+[debug] Using environment: noSuchName
 [debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments
 [debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/environments 200
-[debug] Writing contents to file globalSetupPath
-Active environment: kid_Sy4yRNV_M
+[error] NotFound: Could not find environment with identifier 'noSuchName'.
 
 `
 
-exports['appenv use with profile when active app is not set using existent env id and no app should fail 1'] = `
+exports['appenv use without profile with credentials as options should fail 1'] = `
 [debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-kinvey appenv use <env>
-
-Set the active environment
-
-Positionals:
-  env  Env ID/name                                           [string] [required]
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --app                     App ID/name                                 [string]
-
-Application is required. Please set active app or use the --app option.
-
-`
-
-exports['appenv use with profile when active app is not set without env and without app should fail 1'] = `
-kinvey appenv use <env>
-
-Set the active environment
-
-Positionals:
-  env  Env ID/name                                           [string] [required]
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --app                     App ID/name                                 [string]
-
-Not enough non-option arguments: got 0, need at least 1
+[error] ProfileRequired: Profile is required. Please set active profile or use the --profile option.
 
 `

--- a/__snapshots__/flex-clear.test.js
+++ b/__snapshots__/flex-clear.test.js
@@ -1,16 +1,16 @@
-exports['flex clear when project is not set should succeed and output default format 1'] = `
-[debug] Checking for package updates
-[debug] Writing contents to file projectSetupPath
-Project data cleared. Run kinvey flex init to get started.
-
-`
-
 exports['flex clear when project is not set should succeed and output JSON 1'] = `
 [debug] Checking for package updates
 [debug] Writing contents to file projectSetupPath
 {
   "result": null
 }
+
+`
+
+exports['flex clear when project is not set should succeed and output default format 1'] = `
+[debug] Checking for package updates
+[debug] Writing contents to file projectSetupPath
+Project data cleared. Run kinvey flex init to get started.
 
 `
 
@@ -27,18 +27,23 @@ kinvey flex clear
 Clear project settings
 
 Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
 
 Too many non-option arguments: got 1, maximum of 0
 

--- a/__snapshots__/flex-create.test.js
+++ b/__snapshots__/flex-create.test.js
@@ -1,15 +1,3 @@
-exports['flex create with active profile with a name, secret, basic env vars and app should succeed and output default format 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
-[debug] Request:  POST http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/data-links
-[debug] Response: POST http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/data-links 201
-Created service: 12378kdl2. Secret: 789
-
-`
-
 exports['flex create with active profile with a name, app and invalid env vars should fail 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
@@ -21,26 +9,45 @@ Positionals:
   name  Flex service name                                             [required]
 
 Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --app                     App ID/name                                 [string]
-  --org                     Org ID/name                                 [string]
-  --secret                  Shared secret                               [string]
-  --vars, --set-vars        Environment variables. Specify either as
-                            comma-separated list of key-value pairs
-                            (key1=value1,key2=value2) or in JSON format.
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --app                                     App ID/name                 [string]
+  --org                                     Org ID/name                 [string]
+  --secret                                  Shared secret               [string]
+  --vars, --set-vars                        Environment variables. Specify
+                                            either as comma-separated list of
+                                            key-value pairs
+                                            (key1=value1,key2=value2) or in JSON
+                                            format.
 
 Environment variables must be specified as comma-separated list where key=value or in valid JSON format.
+
+`
+
+exports['flex create with active profile with a name, secret, basic env vars and app should succeed and output default format 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using application: 885f5d307afd4168bebca1a64f815c1e
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e 200
+[debug] Request:  POST http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/data-links
+[debug] Response: POST http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/data-links 201
+Created service: 12378kdl2. Secret: 789
 
 `
 
@@ -54,6 +61,45 @@ exports['flex create with active profile with a name, secret, complex env vars a
 
 `
 
+exports['flex create with active profile with both app and org should fail 1'] = `
+kinvey flex create <name>
+
+Create a Flex service
+
+Positionals:
+  name  Flex service name                                             [required]
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --app                                     App ID/name                 [string]
+  --org                                     Org ID/name                 [string]
+  --secret                                  Shared secret               [string]
+  --vars, --set-vars                        Environment variables. Specify
+                                            either as comma-separated list of
+                                            key-value pairs
+                                            (key1=value1,key2=value2) or in JSON
+                                            format.
+
+Arguments app and org are mutually exclusive
+
+`
+
 exports['flex create with active profile without a name should fail 1'] = `
 kinvey flex create <name>
 
@@ -63,24 +109,31 @@ Positionals:
   name  Flex service name                                             [required]
 
 Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --app                     App ID/name                                 [string]
-  --org                     Org ID/name                                 [string]
-  --secret                  Shared secret                               [string]
-  --vars, --set-vars        Environment variables. Specify either as
-                            comma-separated list of key-value pairs
-                            (key1=value1,key2=value2) or in JSON format.
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --app                                     App ID/name                 [string]
+  --org                                     Org ID/name                 [string]
+  --secret                                  Shared secret               [string]
+  --vars, --set-vars                        Environment variables. Specify
+                                            either as comma-separated list of
+                                            key-value pairs
+                                            (key1=value1,key2=value2) or in JSON
+                                            format.
 
 Not enough non-option arguments: got 0, need at least 1
 
@@ -93,38 +146,6 @@ Created service: 12378kdl2. Secret: 789
 
 exports['flex create with active profile without an app and org should fail 1'] = `
 [error] Error: Either '--app' or '--org' option must be set.
-
-`
-
-exports['flex create with active profile with both app and org should fail 1'] = `
-kinvey flex create <name>
-
-Create a Flex service
-
-Positionals:
-  name  Flex service name                                             [required]
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --app                     App ID/name                                 [string]
-  --org                     Org ID/name                                 [string]
-  --secret                  Shared secret                               [string]
-  --vars, --set-vars        Environment variables. Specify either as
-                            comma-separated list of key-value pairs
-                            (key1=value1,key2=value2) or in JSON format.
-
-Arguments app and org are mutually exclusive
 
 `
 

--- a/__snapshots__/flex-deploy.test.js
+++ b/__snapshots__/flex-deploy.test.js
@@ -1,29 +1,37 @@
-exports['flex deploy when project setup is non-existent by not specifying profile nor credentials when one profile should use it and fail 1'] = `
+exports['flex deploy when project setup exists is not valid and user\'s project is valid should fail 1'] = `
 kinvey flex deploy
 
 Deploy the current project to the Kinvey FlexService Runtime
 
 Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --service                 Service ID                                  [string]
-  --replace-vars            Environment variables (replaces all already
-                            existing). Specify either as comma-separated list of
-                            key-value pairs (key1=value1,key2=value2) or in JSON
-                            format.
-  --set-vars                Environment variables to set. Specify either as
-                            comma-separated list of key-value pairs
-                            (key1=value1,key2=value2) or in JSON format.
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --service                                 Service ID                  [string]
+  --replace-vars                            Environment variables (replaces all
+                                            already existing). Specify either as
+                                            comma-separated list of key-value
+                                            pairs (key1=value1,key2=value2) or
+                                            in JSON format.
+  --set-vars                                Environment variables to set.
+                                            Specify either as comma-separated
+                                            list of key-value pairs
+                                            (key1=value1,key2=value2) or in JSON
+                                            format.
 
 This project is not configured. Use 'kinvey flex init' to get started. Alternatively, use options: service.
 
@@ -34,32 +42,40 @@ exports['flex deploy when project setup exists is valid and user\'s project is i
 
 `
 
-exports['flex deploy when project setup exists is not valid and user\'s project is valid should fail 1'] = `
+exports['flex deploy when project setup is non-existent by not specifying profile nor credentials when one profile should use it and fail 1'] = `
 kinvey flex deploy
 
 Deploy the current project to the Kinvey FlexService Runtime
 
 Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --service                 Service ID                                  [string]
-  --replace-vars            Environment variables (replaces all already
-                            existing). Specify either as comma-separated list of
-                            key-value pairs (key1=value1,key2=value2) or in JSON
-                            format.
-  --set-vars                Environment variables to set. Specify either as
-                            comma-separated list of key-value pairs
-                            (key1=value1,key2=value2) or in JSON format.
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --service                                 Service ID                  [string]
+  --replace-vars                            Environment variables (replaces all
+                                            already existing). Specify either as
+                                            comma-separated list of key-value
+                                            pairs (key1=value1,key2=value2) or
+                                            in JSON format.
+  --set-vars                                Environment variables to set.
+                                            Specify either as comma-separated
+                                            list of key-value pairs
+                                            (key1=value1,key2=value2) or in JSON
+                                            format.
 
 This project is not configured. Use 'kinvey flex init' to get started. Alternatively, use options: service.
 

--- a/__snapshots__/flex-job.test.js
+++ b/__snapshots__/flex-job.test.js
@@ -1,39 +1,3 @@
-exports['flex job by specifying a profile and existent jobId should succeed and output default format 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'profileToGetJobStatus'
-[debug] Project configuration file not found: 'projectSetupPath'.
-[debug] Request:  GET http://localhost:3234/v2/jobs/6fa90d40d78c43f9a8a9a1838de41a37
-[debug] Response: GET http://localhost:3234/v2/jobs/6fa90d40d78c43f9a8a9a1838de41a37 200
-Job status: COMPLETE
-
-`
-
-exports['flex job by specifying a profile and existent jobId should succeed and output JSON 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'profileToGetJobStatus'
-[debug] Project configuration file not found: 'projectSetupPath'.
-[debug] Request:  GET http://localhost:3234/v2/jobs/6fa90d40d78c43f9a8a9a1838de41a37
-[debug] Response: GET http://localhost:3234/v2/jobs/6fa90d40d78c43f9a8a9a1838de41a37 200
-{
-  "result": {
-    "status": "COMPLETE",
-    "progress": "Deploying service.",
-    "jobId": "6fa90d40d78c43f9a8a9a1838de41a37"
-  }
-}
-
-`
-
-exports['flex job by specifying a profile and non-existent jobId should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'profileToGetJobStatus'
-[debug] Project configuration file not found: 'projectSetupPath'.
-[debug] Request:  GET http://localhost:3234/v2/jobs/123jobDoesntExist
-[debug] Response: GET http://localhost:3234/v2/jobs/123jobDoesntExist 404
-[error] JobNotFound: The specified job could not be found.
-
-`
-
 exports['flex job by not specifying profile nor credentials when one profile and existent jobId should succeed 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'flexJobProfile'
@@ -53,20 +17,70 @@ Positionals:
   id  Job ID
 
 Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
 
 You must be authenticated.
+
+`
+
+exports['flex job by specifying a profile and existent jobId should succeed and output JSON 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'profileToGetJobStatus'
+[debug] Project configuration file not found: 'projectSetupPath'.
+[debug] Request:  GET http://localhost:3234/v2/jobs/6fa90d40d78c43f9a8a9a1838de41a37
+[debug] Response: GET http://localhost:3234/v2/jobs/6fa90d40d78c43f9a8a9a1838de41a37 200
+{
+  "result": {
+    "status": "COMPLETE",
+    "progress": "Deploying service.",
+    "jobId": "6fa90d40d78c43f9a8a9a1838de41a37"
+  }
+}
+
+`
+
+exports['flex job by specifying a profile and existent jobId should succeed and output default format 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'profileToGetJobStatus'
+[debug] Project configuration file not found: 'projectSetupPath'.
+[debug] Request:  GET http://localhost:3234/v2/jobs/6fa90d40d78c43f9a8a9a1838de41a37
+[debug] Response: GET http://localhost:3234/v2/jobs/6fa90d40d78c43f9a8a9a1838de41a37 200
+Job status: COMPLETE
+
+`
+
+exports['flex job by specifying a profile and non-existent jobId should fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'profileToGetJobStatus'
+[debug] Project configuration file not found: 'projectSetupPath'.
+[debug] Request:  GET http://localhost:3234/v2/jobs/123jobDoesntExist
+[debug] Response: GET http://localhost:3234/v2/jobs/123jobDoesntExist 404
+[error] JobNotFound: The specified job could not be found.
+
+`
+
+exports['flex job by specifying credentials as options when invalid and existent jobId should fail 1'] = `
+[debug] Checking for package updates
+[debug] Logging in user: johnDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 401
+[error] InvalidCredentials: Credentials are invalid. Please authenticate.
 
 `
 
@@ -95,15 +109,6 @@ exports['flex job by specifying credentials as options when valid and non-existe
 [debug] Response: DELETE http://localhost:3234/session 204
 [debug] Logged out current user.
 [error] JobNotFound: The specified job could not be found.
-
-`
-
-exports['flex job by specifying credentials as options when invalid and existent jobId should fail 1'] = `
-[debug] Checking for package updates
-[debug] Logging in user: johnDoe@mail.com
-[debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 401
-[error] InvalidCredentials: Credentials are invalid. Please authenticate.
 
 `
 

--- a/__snapshots__/flex-list.test.js
+++ b/__snapshots__/flex-list.test.js
@@ -1,22 +1,63 @@
-exports['flex list by specifying credentials as options when valid and valid options should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Logging in user: janeyDoe@mail.com
-[debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 200
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/data-links
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/data-links 200
-[debug] Request:  DELETE http://localhost:3234/session
-[debug] Response: DELETE http://localhost:3234/session 204
-[debug] Logged out current user.
-Count: 3
+exports['flex list by not specifying profile nor credentials when several profiles should fail 1'] = `
+kinvey flex list
 
-id                                name                    
---------------------------------  ------------------------
-12378kdl2                         TestKinveyDatalink      
-0de22ffb3f2243ec8138170844envVar  TestKinveyService       
-12389kd89                         TestSecondKinveyDatalink
+List Internal Flex Services for an app or org
 
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --domain                                  Specify domain: 'app' or 'org'
+                                                [string] [choices: "app", "org"]
+  --id                                      ID of app or org            [string]
 
+You must be authenticated.
+
+`
+
+exports['flex list by specifying a profile and invalid domain with valid id should fail 1'] = `
+kinvey flex list
+
+List Internal Flex Services for an app or org
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --domain                                  Specify domain: 'app' or 'org'
+                                                [string] [choices: "app", "org"]
+  --id                                      ID of app or org            [string]
+
+Invalid values:
+  Argument: domain, Given: "invalidDomain", Choices: "app", "org"
 
 `
 
@@ -63,30 +104,20 @@ exports['flex list by specifying a profile and valid options (org and id) should
 
 `
 
-exports['flex list by specifying a profile and invalid domain with valid id should fail 1'] = `
-kinvey flex list
+exports['flex list by specifying a profile when invalid project is set with valid options should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'profileToGetServices'
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/data-links
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/data-links 200
+Count: 3
 
-List Internal Flex Services for an app or org
+id                                name                    
+--------------------------------  ------------------------
+12378kdl2                         TestKinveyDatalink      
+0de22ffb3f2243ec8138170844envVar  TestKinveyService       
+12389kd89                         TestSecondKinveyDatalink
 
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --domain                  Specify domain: 'app' or 'org'
-                                                [string] [choices: "app", "org"]
-  --id                      ID of app or org                            [string]
 
-Invalid values:
-  Argument: domain, Given: "invalidDomain", Choices: "app", "org"
 
 `
 
@@ -107,46 +138,12 @@ id                                name
 
 `
 
-exports['flex list by specifying a profile when invalid project is set with valid options should succeed 1'] = `
+exports['flex list by specifying credentials as options when invalid and valid options should fail 1'] = `
 [debug] Checking for package updates
-[debug] Using profile 'profileToGetServices'
-[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/data-links
-[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/data-links 200
-Count: 3
-
-id                                name                    
---------------------------------  ------------------------
-12378kdl2                         TestKinveyDatalink      
-0de22ffb3f2243ec8138170844envVar  TestKinveyService       
-12389kd89                         TestSecondKinveyDatalink
-
-
-
-`
-
-exports['flex list by not specifying profile nor credentials when several profiles should fail 1'] = `
-kinvey flex list
-
-List Internal Flex Services for an app or org
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --domain                  Specify domain: 'app' or 'org'
-                                                [string] [choices: "app", "org"]
-  --id                      ID of app or org                            [string]
-
-You must be authenticated.
+[debug] Logging in user: johnDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 401
+[error] InvalidCredentials: Credentials are invalid. Please authenticate.
 
 `
 
@@ -164,11 +161,24 @@ exports['flex list by specifying credentials as options when valid and non-exist
 
 `
 
-exports['flex list by specifying credentials as options when invalid and valid options should fail 1'] = `
+exports['flex list by specifying credentials as options when valid and valid options should succeed 1'] = `
 [debug] Checking for package updates
-[debug] Logging in user: johnDoe@mail.com
+[debug] Logging in user: janeyDoe@mail.com
 [debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 401
-[error] InvalidCredentials: Credentials are invalid. Please authenticate.
+[debug] Response: POST http://localhost:3234/session 200
+[debug] Request:  GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/data-links
+[debug] Response: GET http://localhost:3234/v2/apps/885f5d307afd4168bebca1a64f815c1e/data-links 200
+[debug] Request:  DELETE http://localhost:3234/session
+[debug] Response: DELETE http://localhost:3234/session 204
+[debug] Logged out current user.
+Count: 3
+
+id                                name                    
+--------------------------------  ------------------------
+12378kdl2                         TestKinveyDatalink      
+0de22ffb3f2243ec8138170844envVar  TestKinveyService       
+12389kd89                         TestSecondKinveyDatalink
+
+
 
 `

--- a/__snapshots__/flex-logs.test.js
+++ b/__snapshots__/flex-logs.test.js
@@ -1,9 +1,25 @@
-exports['flex logs without query by specifying a profile and existent serviceId without query should succeed 1'] = `
+exports['flex logs with query with invalid start timestamp and nothing else should fail 1'] = `
 [debug] Checking for package updates
-[debug] Using profile 'profileToGetLogs'
+[debug] Using profile 'profileToSetAsActive'
 [debug] Project configuration file not found: 'projectSetupPath'.
-[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs
-[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs 200
+[error] InvalidParameter: Logs 'from' flag invalid (ISO-8601 timestamp expected)
+
+`
+
+exports['flex logs with query with invalid timestamps (\'from\' not before \'to\') and nothing else should fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'profileToSetAsActive'
+[debug] Project configuration file not found: 'projectSetupPath'.
+[error] InvalidParameter: 'from' timestamp must be before 'to' timestamp.
+
+`
+
+exports['flex logs with query with valid start timestamp and nothing else should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'profileToSetAsActive'
+[debug] Project configuration file not found: 'projectSetupPath'.
+[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs?from=2017-08-30T08:06:49.594Z
+[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs?from=2017-08-30T08:06:49.594Z 200
 Count: 5
 
 containerId   timestamp                 threshold  message                                                
@@ -18,21 +34,20 @@ containerId   timestamp                 threshold  message
 
 `
 
-exports['flex logs without query by specifying a profile and non-existent serviceId should fail 1'] = `
+exports['flex logs with query with valid timestamps and invalid paging should fail 1'] = `
 [debug] Checking for package updates
-[debug] Using profile 'profileToGetLogs'
+[debug] Using profile 'profileToSetAsActive'
 [debug] Project configuration file not found: 'projectSetupPath'.
-[debug] Request:  GET http://localhost:3234/v2/data-links/12serviceIdThatDoesntExist/logs
-[debug] Response: GET http://localhost:3234/v2/data-links/12serviceIdThatDoesntExist/logs 404
-[error] DataLinkNotFound: The specified data link could not be found.
+[error] InvalidParameter: Logs 'page' flag invalid (non-zero integer expected)
 
 `
 
-exports['flex logs without query by specifying a profile when valid project is set without serviceId as an option should succeed 1'] = `
+exports['flex logs with query with valid timestamps and valid paging should succeed 1'] = `
 [debug] Checking for package updates
-[debug] Using profile 'profileToGetLogs'
-[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs
-[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs 200
+[debug] Using profile 'profileToSetAsActive'
+[debug] Project configuration file not found: 'projectSetupPath'.
+[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs?from=2017-08-30T08:06:49.594Z&to=2017-09-02T08:06:49&limit=5&page=3
+[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs?from=2017-08-30T08:06:49.594Z&to=2017-09-02T08:06:49&limit=5&page=3 200
 Count: 5
 
 containerId   timestamp                 threshold  message                                                
@@ -47,11 +62,12 @@ containerId   timestamp                 threshold  message
 
 `
 
-exports['flex logs without query by specifying a profile when invalid project is set with existent serviceId as an option should succeed 1'] = `
+exports['flex logs with query with valid timestamps and without paging should succeed 1'] = `
 [debug] Checking for package updates
-[debug] Using profile 'profileToGetLogs'
-[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs
-[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs 200
+[debug] Using profile 'profileToSetAsActive'
+[debug] Project configuration file not found: 'projectSetupPath'.
+[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs?from=2017-08-30T08:06:49.594Z&to=2017-09-02T08:06:49.000Z
+[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs?from=2017-08-30T08:06:49.594Z&to=2017-09-02T08:06:49.000Z 200
 Count: 5
 
 containerId   timestamp                 threshold  message                                                
@@ -66,42 +82,32 @@ containerId   timestamp                 threshold  message
 
 `
 
-exports['flex logs without query by specifying a profile when project is not set without serviceId as an option should fail 1'] = `
-kinvey flex logs
+exports['flex logs with query without timestamps and page but with valid size should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'profileToSetAsActive'
+[debug] Project configuration file not found: 'projectSetupPath'.
+[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs?limit=35
+[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs?limit=35 200
+Count: 5
 
-Retrieve and display Internal Flex Service logs
+containerId   timestamp                 threshold  message                                                
+------------  ------------------------  ---------  -------------------------------------------------------
+3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
+3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/rc.local...                           
+3864f1602739  2017-08-30T08:06:49.595Z  null       *** Runit started as PID 11                            
+3864f1602739  2017-08-30T08:06:49.595Z  warn       *** Booting runit daemon...                            
+3864f1602739  2017-08-30T08:06:49.595Z  info       {"name":"test","num":10}                               
 
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --service                 Service ID                                  [string]
-  --from                    Fetch log entries starting from provided timestamp
-                                                                        [string]
-  --to                      Fetch log entries up to provided timestamp  [string]
-  --page                    Page (non-zero integer, default=1)          [number]
-  --number, -n              Number of entries to fetch, i.e. page size (non-zero
-                            integer, default=100, max=2000)             [number]
 
-This project is not configured. Use 'kinvey flex init' to get started. Alternatively, use options: service.
 
 `
 
-exports['flex logs without query by not specifying profile nor credentials when one profile and existent serviceId should succeed and output default format 1'] = `
+exports['flex logs with query without timestamps and valid paging should succeed 1'] = `
 [debug] Checking for package updates
-[debug] Using profile 'flexLogsProfile'
+[debug] Using profile 'profileToSetAsActive'
 [debug] Project configuration file not found: 'projectSetupPath'.
-[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs
-[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs 200
+[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs?limit=5&page=3
+[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs?limit=5&page=3 200
 Count: 5
 
 containerId   timestamp                 threshold  message                                                
@@ -162,33 +168,176 @@ exports['flex logs without query by not specifying profile nor credentials when 
 
 `
 
+exports['flex logs without query by not specifying profile nor credentials when one profile and existent serviceId should succeed and output default format 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'flexLogsProfile'
+[debug] Project configuration file not found: 'projectSetupPath'.
+[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs
+[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs 200
+Count: 5
+
+containerId   timestamp                 threshold  message                                                
+------------  ------------------------  ---------  -------------------------------------------------------
+3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
+3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/rc.local...                           
+3864f1602739  2017-08-30T08:06:49.595Z  null       *** Runit started as PID 11                            
+3864f1602739  2017-08-30T08:06:49.595Z  warn       *** Booting runit daemon...                            
+3864f1602739  2017-08-30T08:06:49.595Z  info       {"name":"test","num":10}                               
+
+
+
+`
+
 exports['flex logs without query by not specifying profile nor credentials when several profiles and existent serviceId should fail 1'] = `
 kinvey flex logs
 
 Retrieve and display Internal Flex Service logs
 
 Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --service                 Service ID                                  [string]
-  --from                    Fetch log entries starting from provided timestamp
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
                                                                         [string]
-  --to                      Fetch log entries up to provided timestamp  [string]
-  --page                    Page (non-zero integer, default=1)          [number]
-  --number, -n              Number of entries to fetch, i.e. page size (non-zero
-                            integer, default=100, max=2000)             [number]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --service                                 Service ID                  [string]
+  --from                                    Fetch log entries starting from
+                                            provided timestamp          [string]
+  --to                                      Fetch log entries up to provided
+                                            timestamp                   [string]
+  --page                                    Page (non-zero integer, default=1)
+                                                                        [number]
+  --number, -n                              Number of entries to fetch, i.e.
+                                            page size (non-zero integer,
+                                            default=100, max=2000)      [number]
 
 You must be authenticated.
+
+`
+
+exports['flex logs without query by specifying a profile and existent serviceId without query should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'profileToGetLogs'
+[debug] Project configuration file not found: 'projectSetupPath'.
+[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs
+[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs 200
+Count: 5
+
+containerId   timestamp                 threshold  message                                                
+------------  ------------------------  ---------  -------------------------------------------------------
+3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
+3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/rc.local...                           
+3864f1602739  2017-08-30T08:06:49.595Z  null       *** Runit started as PID 11                            
+3864f1602739  2017-08-30T08:06:49.595Z  warn       *** Booting runit daemon...                            
+3864f1602739  2017-08-30T08:06:49.595Z  info       {"name":"test","num":10}                               
+
+
+
+`
+
+exports['flex logs without query by specifying a profile and non-existent serviceId should fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'profileToGetLogs'
+[debug] Project configuration file not found: 'projectSetupPath'.
+[debug] Request:  GET http://localhost:3234/v2/data-links/12serviceIdThatDoesntExist/logs
+[debug] Response: GET http://localhost:3234/v2/data-links/12serviceIdThatDoesntExist/logs 404
+[error] DataLinkNotFound: The specified data link could not be found.
+
+`
+
+exports['flex logs without query by specifying a profile when invalid project is set with existent serviceId as an option should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'profileToGetLogs'
+[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs
+[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs 200
+Count: 5
+
+containerId   timestamp                 threshold  message                                                
+------------  ------------------------  ---------  -------------------------------------------------------
+3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
+3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/rc.local...                           
+3864f1602739  2017-08-30T08:06:49.595Z  null       *** Runit started as PID 11                            
+3864f1602739  2017-08-30T08:06:49.595Z  warn       *** Booting runit daemon...                            
+3864f1602739  2017-08-30T08:06:49.595Z  info       {"name":"test","num":10}                               
+
+
+
+`
+
+exports['flex logs without query by specifying a profile when project is not set without serviceId as an option should fail 1'] = `
+kinvey flex logs
+
+Retrieve and display Internal Flex Service logs
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --service                                 Service ID                  [string]
+  --from                                    Fetch log entries starting from
+                                            provided timestamp          [string]
+  --to                                      Fetch log entries up to provided
+                                            timestamp                   [string]
+  --page                                    Page (non-zero integer, default=1)
+                                                                        [number]
+  --number, -n                              Number of entries to fetch, i.e.
+                                            page size (non-zero integer,
+                                            default=100, max=2000)      [number]
+
+This project is not configured. Use 'kinvey flex init' to get started. Alternatively, use options: service.
+
+`
+
+exports['flex logs without query by specifying a profile when valid project is set without serviceId as an option should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'profileToGetLogs'
+[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs
+[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs 200
+Count: 5
+
+containerId   timestamp                 threshold  message                                                
+------------  ------------------------  ---------  -------------------------------------------------------
+3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
+3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/rc.local...                           
+3864f1602739  2017-08-30T08:06:49.595Z  null       *** Runit started as PID 11                            
+3864f1602739  2017-08-30T08:06:49.595Z  warn       *** Booting runit daemon...                            
+3864f1602739  2017-08-30T08:06:49.595Z  info       {"name":"test","num":10}                               
+
+
+
+`
+
+exports['flex logs without query by specifying credentials as options when invalid and existent serviceId should fail 1'] = `
+[debug] Checking for package updates
+[debug] Logging in user: johnDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 401
+[error] InvalidCredentials: Credentials are invalid. Please authenticate.
 
 `
 
@@ -227,138 +376,5 @@ exports['flex logs without query by specifying credentials as options when valid
 [debug] Response: DELETE http://localhost:3234/session 204
 [debug] Logged out current user.
 [error] DataLinkNotFound: The specified data link could not be found.
-
-`
-
-exports['flex logs without query by specifying credentials as options when invalid and existent serviceId should fail 1'] = `
-[debug] Checking for package updates
-[debug] Logging in user: johnDoe@mail.com
-[debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 401
-[error] InvalidCredentials: Credentials are invalid. Please authenticate.
-
-`
-
-exports['flex logs with query with valid timestamps and valid paging should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'profileToSetAsActive'
-[debug] Project configuration file not found: 'projectSetupPath'.
-[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs?from=2017-08-30T08:06:49.594Z&to=2017-09-02T08:06:49&limit=5&page=3
-[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs?from=2017-08-30T08:06:49.594Z&to=2017-09-02T08:06:49&limit=5&page=3 200
-Count: 5
-
-containerId   timestamp                 threshold  message                                                
-------------  ------------------------  ---------  -------------------------------------------------------
-3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
-3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/rc.local...                           
-3864f1602739  2017-08-30T08:06:49.595Z  null       *** Runit started as PID 11                            
-3864f1602739  2017-08-30T08:06:49.595Z  warn       *** Booting runit daemon...                            
-3864f1602739  2017-08-30T08:06:49.595Z  info       {"name":"test","num":10}                               
-
-
-
-`
-
-exports['flex logs with query with valid timestamps and without paging should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'profileToSetAsActive'
-[debug] Project configuration file not found: 'projectSetupPath'.
-[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs?from=2017-08-30T08:06:49.594Z&to=2017-09-02T08:06:49.000Z
-[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs?from=2017-08-30T08:06:49.594Z&to=2017-09-02T08:06:49.000Z 200
-Count: 5
-
-containerId   timestamp                 threshold  message                                                
-------------  ------------------------  ---------  -------------------------------------------------------
-3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
-3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/rc.local...                           
-3864f1602739  2017-08-30T08:06:49.595Z  null       *** Runit started as PID 11                            
-3864f1602739  2017-08-30T08:06:49.595Z  warn       *** Booting runit daemon...                            
-3864f1602739  2017-08-30T08:06:49.595Z  info       {"name":"test","num":10}                               
-
-
-
-`
-
-exports['flex logs with query with valid timestamps and invalid paging should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'profileToSetAsActive'
-[debug] Project configuration file not found: 'projectSetupPath'.
-[error] InvalidParameter: Logs 'page' flag invalid (non-zero integer expected)
-
-`
-
-exports['flex logs with query with valid start timestamp and nothing else should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'profileToSetAsActive'
-[debug] Project configuration file not found: 'projectSetupPath'.
-[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs?from=2017-08-30T08:06:49.594Z
-[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs?from=2017-08-30T08:06:49.594Z 200
-Count: 5
-
-containerId   timestamp                 threshold  message                                                
-------------  ------------------------  ---------  -------------------------------------------------------
-3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
-3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/rc.local...                           
-3864f1602739  2017-08-30T08:06:49.595Z  null       *** Runit started as PID 11                            
-3864f1602739  2017-08-30T08:06:49.595Z  warn       *** Booting runit daemon...                            
-3864f1602739  2017-08-30T08:06:49.595Z  info       {"name":"test","num":10}                               
-
-
-
-`
-
-exports['flex logs with query with invalid start timestamp and nothing else should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'profileToSetAsActive'
-[debug] Project configuration file not found: 'projectSetupPath'.
-[error] InvalidParameter: Logs 'from' flag invalid (ISO-8601 timestamp expected)
-
-`
-
-exports['flex logs with query with invalid timestamps (\'from\' not before \'to\') and nothing else should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'profileToSetAsActive'
-[debug] Project configuration file not found: 'projectSetupPath'.
-[error] InvalidParameter: 'from' timestamp must be before 'to' timestamp.
-
-`
-
-exports['flex logs with query without timestamps and valid paging should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'profileToSetAsActive'
-[debug] Project configuration file not found: 'projectSetupPath'.
-[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs?limit=5&page=3
-[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs?limit=5&page=3 200
-Count: 5
-
-containerId   timestamp                 threshold  message                                                
-------------  ------------------------  ---------  -------------------------------------------------------
-3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
-3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/rc.local...                           
-3864f1602739  2017-08-30T08:06:49.595Z  null       *** Runit started as PID 11                            
-3864f1602739  2017-08-30T08:06:49.595Z  warn       *** Booting runit daemon...                            
-3864f1602739  2017-08-30T08:06:49.595Z  info       {"name":"test","num":10}                               
-
-
-
-`
-
-exports['flex logs with query without timestamps and page but with valid size should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'profileToSetAsActive'
-[debug] Project configuration file not found: 'projectSetupPath'.
-[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/logs?limit=35
-[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/logs?limit=35 200
-Count: 5
-
-containerId   timestamp                 threshold  message                                                
-------------  ------------------------  ---------  -------------------------------------------------------
-3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
-3864f1602739  2017-08-30T08:06:49.594Z  null       *** Running /etc/rc.local...                           
-3864f1602739  2017-08-30T08:06:49.595Z  null       *** Runit started as PID 11                            
-3864f1602739  2017-08-30T08:06:49.595Z  warn       *** Booting runit daemon...                            
-3864f1602739  2017-08-30T08:06:49.595Z  info       {"name":"test","num":10}                               
-
-
 
 `

--- a/__snapshots__/flex-recycle.test.js
+++ b/__snapshots__/flex-recycle.test.js
@@ -1,61 +1,3 @@
-exports['flex recycle by specifying a profile and existent serviceId should succeed and output default format 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'profileToRecycleService'
-[debug] Project configuration file not found: 'projectSetupPath'.
-[debug] Request:  POST http://localhost:3234/v2/jobs
-[debug] Response: POST http://localhost:3234/v2/jobs 200
-[debug] Writing contents to file projectSetupPath
-[debug] Saved job ID to project settings.
-Recycle initiated. Job: idOfJobThatIsRecyclingTheService
-
-`
-
-exports['flex recycle by specifying a profile and existent serviceId should succeed and output JSON 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'profileToRecycleService'
-[debug] Request:  POST http://localhost:3234/v2/jobs
-[debug] Response: POST http://localhost:3234/v2/jobs 200
-[debug] Writing contents to file projectSetupPath
-[debug] Saved job ID to project settings.
-{
-  "result": {
-    "id": "idOfJobThatIsRecyclingTheService"
-  }
-}
-
-`
-
-exports['flex recycle by specifying a profile and non-existent serviceId should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'profileToRecycleService'
-[debug] Request:  POST http://localhost:3234/v2/jobs
-[debug] Response: POST http://localhost:3234/v2/jobs 404
-[error] DataLinkNotFound: The specified data link could not be found.
-
-`
-
-exports['flex recycle by specifying a profile when valid project is set without serviceId as an option should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'profileToRecycleService'
-[debug] Request:  POST http://localhost:3234/v2/jobs
-[debug] Response: POST http://localhost:3234/v2/jobs 200
-[debug] Writing contents to file projectSetupPath
-[debug] Saved job ID to project settings.
-Recycle initiated. Job: idOfJobThatIsRecyclingTheService
-
-`
-
-exports['flex recycle by specifying a profile when invalid project is set with existent serviceId as an option should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'profileToRecycleService'
-[debug] Request:  POST http://localhost:3234/v2/jobs
-[debug] Response: POST http://localhost:3234/v2/jobs 200
-[debug] Writing contents to file projectSetupPath
-[debug] Saved job ID to project settings.
-Recycle initiated. Job: idOfJobThatIsRecyclingTheService
-
-`
-
 exports['flex recycle by not specifying profile nor credentials when one profile and existent serviceId should succeed 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'flexStatusProfile'
@@ -74,21 +16,93 @@ kinvey flex recycle
 Recycle the Service
 
 Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --service                 Service ID                                  [string]
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --service                                 Service ID                  [string]
 
 You must be authenticated.
+
+`
+
+exports['flex recycle by specifying a profile and existent serviceId should succeed and output JSON 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'profileToRecycleService'
+[debug] Request:  POST http://localhost:3234/v2/jobs
+[debug] Response: POST http://localhost:3234/v2/jobs 200
+[debug] Writing contents to file projectSetupPath
+[debug] Saved job ID to project settings.
+{
+  "result": {
+    "id": "idOfJobThatIsRecyclingTheService"
+  }
+}
+
+`
+
+exports['flex recycle by specifying a profile and existent serviceId should succeed and output default format 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'profileToRecycleService'
+[debug] Project configuration file not found: 'projectSetupPath'.
+[debug] Request:  POST http://localhost:3234/v2/jobs
+[debug] Response: POST http://localhost:3234/v2/jobs 200
+[debug] Writing contents to file projectSetupPath
+[debug] Saved job ID to project settings.
+Recycle initiated. Job: idOfJobThatIsRecyclingTheService
+
+`
+
+exports['flex recycle by specifying a profile and non-existent serviceId should fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'profileToRecycleService'
+[debug] Request:  POST http://localhost:3234/v2/jobs
+[debug] Response: POST http://localhost:3234/v2/jobs 404
+[error] DataLinkNotFound: The specified data link could not be found.
+
+`
+
+exports['flex recycle by specifying a profile when invalid project is set with existent serviceId as an option should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'profileToRecycleService'
+[debug] Request:  POST http://localhost:3234/v2/jobs
+[debug] Response: POST http://localhost:3234/v2/jobs 200
+[debug] Writing contents to file projectSetupPath
+[debug] Saved job ID to project settings.
+Recycle initiated. Job: idOfJobThatIsRecyclingTheService
+
+`
+
+exports['flex recycle by specifying a profile when valid project is set without serviceId as an option should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'profileToRecycleService'
+[debug] Request:  POST http://localhost:3234/v2/jobs
+[debug] Response: POST http://localhost:3234/v2/jobs 200
+[debug] Writing contents to file projectSetupPath
+[debug] Saved job ID to project settings.
+Recycle initiated. Job: idOfJobThatIsRecyclingTheService
+
+`
+
+exports['flex recycle by specifying credentials as options when invalid and existent serviceId should fail 1'] = `
+[debug] Checking for package updates
+[debug] Logging in user: johnDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 401
+[error] InvalidCredentials: Credentials are invalid. Please authenticate.
 
 `
 
@@ -117,14 +131,5 @@ exports['flex recycle by specifying credentials as options when valid and non-ex
 [debug] Response: DELETE http://localhost:3234/session 204
 [debug] Logged out current user.
 [error] DataLinkNotFound: The specified data link could not be found.
-
-`
-
-exports['flex recycle by specifying credentials as options when invalid and existent serviceId should fail 1'] = `
-[debug] Checking for package updates
-[debug] Logging in user: johnDoe@mail.com
-[debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 401
-[error] InvalidCredentials: Credentials are invalid. Please authenticate.
 
 `

--- a/__snapshots__/flex-status.test.js
+++ b/__snapshots__/flex-status.test.js
@@ -1,6 +1,6 @@
-exports['flex status by specifying a profile and existent serviceId should succeed and output default format 1'] = `
+exports['flex status by not specifying profile nor credentials when one profile and existent serviceId should succeed 1'] = `
 [debug] Checking for package updates
-[debug] Using profile 'profileToGetServiceStatus'
+[debug] Using profile 'flexStatusProfile'
 [debug] Project configuration file not found: 'projectSetupPath'.
 [debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/status
 [debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/status 200
@@ -13,6 +13,35 @@ requestedAt    replaced_value
 deployerEmail  davy.jones@mail.com                  
 deployerName   Davy Jones                           
 
+
+`
+
+exports['flex status by not specifying profile nor credentials when several profiles and existent serviceId should fail 1'] = `
+kinvey flex status
+
+Return the health of a Flex Service cluster
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --service                                 Service ID                  [string]
+
+You must be authenticated.
 
 `
 
@@ -34,6 +63,24 @@ exports['flex status by specifying a profile and existent serviceId should succe
     "version": "1.4.2"
   }
 }
+
+`
+
+exports['flex status by specifying a profile and existent serviceId should succeed and output default format 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'profileToGetServiceStatus'
+[debug] Project configuration file not found: 'projectSetupPath'.
+[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/status
+[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/status 200
+key            value                                
+-------------  -------------------------------------
+status         ONLINE                               
+version        1.4.2                                
+id             12378kdl2                            
+requestedAt    replaced_value
+deployerEmail  davy.jones@mail.com                  
+deployerName   Davy Jones                           
+
 
 `
 
@@ -64,16 +111,16 @@ deployerName   Davy Jones
 
 `
 
-exports['flex status by not specifying profile nor credentials when one profile and existent serviceId should succeed 1'] = `
+exports['flex status by specifying a profile when valid project is set without serviceId as an option should succeed 1'] = `
 [debug] Checking for package updates
-[debug] Using profile 'flexStatusProfile'
-[debug] Project configuration file not found: 'projectSetupPath'.
+[debug] Using profile 'profileToGetServiceStatus'
 [debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/status
 [debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/status 200
 key            value                                
 -------------  -------------------------------------
 status         ONLINE                               
 version        1.4.2                                
+name           TestKinveyDatalink                   
 id             12378kdl2                            
 requestedAt    replaced_value
 deployerEmail  davy.jones@mail.com                  
@@ -82,48 +129,37 @@ deployerName   Davy Jones
 
 `
 
-exports['flex status by not specifying profile nor credentials when several profiles and existent serviceId should fail 1'] = `
-kinvey flex status
-
-Return the health of a Flex Service cluster
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --service                 Service ID                                  [string]
-
-You must be authenticated.
+exports['flex status by specifying credentials as options when invalid and existent serviceId should fail 1'] = `
+[debug] Checking for package updates
+[debug] Logging in user: johnDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 401
+[error] InvalidCredentials: Credentials are invalid. Please authenticate.
 
 `
 
-exports['flex status by specifying credentials as options when valid and existent serviceId should succeed 1'] = `
+exports['flex status by specifying credentials as options when valid and existent serviceId should succeed (with missing runtime) 1'] = `
 [debug] Checking for package updates
 [debug] Logging in user: janeyDoe@mail.com
 [debug] Request:  POST http://localhost:3234/session
 [debug] Response: POST http://localhost:3234/session 200
-[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/status
-[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/status 200
+[debug] Request:  GET http://localhost:3234/v2/data-links/1234567/status
+[debug] Response: GET http://localhost:3234/v2/data-links/1234567/status 200
 [debug] Request:  DELETE http://localhost:3234/session
 [debug] Response: DELETE http://localhost:3234/session 204
 [debug] Logged out current user.
-key            value                                
--------------  -------------------------------------
-status         ONLINE                               
-version        1.4.2                                
-id             12378kdl2                            
-requestedAt    replaced_value
-deployerEmail  davy.jones@mail.com                  
-deployerName   Davy Jones                           
+key                value                                
+-----------------  -------------------------------------
+status             UPDATING                             
+version            1.4.2                                
+runtime            UNKNOWN                              
+id                 1234567                              
+requestedAt        replaced_value
+deployerEmail      davy.jones@mail.com                  
+deployerName       Davy Jones                           
+deploymentStatus   RUNNING                              
+deploymentVersion  1.4.3                                
+deploymentRuntime  FLEX-RUNTIME-NODE10                  
 
 
 `
@@ -154,28 +190,24 @@ deploymentRuntime  FLEX-RUNTIME-NODE10
 
 `
 
-exports['flex status by specifying credentials as options when valid and existent serviceId should succeed (with missing runtime) 1'] = `
+exports['flex status by specifying credentials as options when valid and existent serviceId should succeed 1'] = `
 [debug] Checking for package updates
 [debug] Logging in user: janeyDoe@mail.com
 [debug] Request:  POST http://localhost:3234/session
 [debug] Response: POST http://localhost:3234/session 200
-[debug] Request:  GET http://localhost:3234/v2/data-links/1234567/status
-[debug] Response: GET http://localhost:3234/v2/data-links/1234567/status 200
+[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/status
+[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/status 200
 [debug] Request:  DELETE http://localhost:3234/session
 [debug] Response: DELETE http://localhost:3234/session 204
 [debug] Logged out current user.
-key                value                                
------------------  -------------------------------------
-status             UPDATING                             
-version            1.4.2                                
-runtime            UNKNOWN                              
-id                 1234567                              
-requestedAt        replaced_value
-deployerEmail      davy.jones@mail.com                  
-deployerName       Davy Jones                           
-deploymentStatus   RUNNING                              
-deploymentVersion  1.4.3                                
-deploymentRuntime  FLEX-RUNTIME-NODE10                  
+key            value                                
+-------------  -------------------------------------
+status         ONLINE                               
+version        1.4.2                                
+id             12378kdl2                            
+requestedAt    replaced_value
+deployerEmail  davy.jones@mail.com                  
+deployerName   Davy Jones                           
 
 
 `
@@ -191,32 +223,5 @@ exports['flex status by specifying credentials as options when valid and non-exi
 [debug] Response: DELETE http://localhost:3234/session 204
 [debug] Logged out current user.
 [error] DataLinkNotFound: The specified data link could not be found.
-
-`
-
-exports['flex status by specifying credentials as options when invalid and existent serviceId should fail 1'] = `
-[debug] Checking for package updates
-[debug] Logging in user: johnDoe@mail.com
-[debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 401
-[error] InvalidCredentials: Credentials are invalid. Please authenticate.
-
-`
-
-exports['flex status by specifying a profile when valid project is set without serviceId as an option should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'profileToGetServiceStatus'
-[debug] Request:  GET http://localhost:3234/v2/data-links/12378kdl2/status
-[debug] Response: GET http://localhost:3234/v2/data-links/12378kdl2/status 200
-key            value                                
--------------  -------------------------------------
-status         ONLINE                               
-version        1.4.2                                
-name           TestKinveyDatalink                   
-id             12378kdl2                            
-requestedAt    replaced_value
-deployerEmail  davy.jones@mail.com                  
-deployerName   Davy Jones                           
-
 
 `

--- a/__snapshots__/flex-update.test.js
+++ b/__snapshots__/flex-update.test.js
@@ -1,3 +1,96 @@
+exports['flex update by specifying a profile when invalid project is set with existent service as an option and single env var (set) should succeed 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'primaryProfile'
+[debug] Request:  GET http://localhost:3234/v2/data-links/0de22ffb3f2243ec8138170844envVar
+[debug] Response: GET http://localhost:3234/v2/data-links/0de22ffb3f2243ec8138170844envVar 200
+[debug] Request:  PUT http://localhost:3234/v2/data-links/0de22ffb3f2243ec8138170844envVar
+[debug] Response: PUT http://localhost:3234/v2/data-links/0de22ffb3f2243ec8138170844envVar 200
+Updated service: 0de22ffb3f2243ec8138170844envVar
+
+`
+
+exports['flex update by specifying a profile when valid project is set with both set and replace env vars should fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'primaryProfile'
+kinvey flex update
+
+Update environment variables
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --service                                 Service ID                  [string]
+  --replace-vars                            Environment variables (replaces all
+                                            already existing). Specify either as
+                                            comma-separated list of key-value
+                                            pairs (key1=value1,key2=value2) or
+                                            in JSON format.
+  --set-vars                                Environment variables to set.
+                                            Specify either as comma-separated
+                                            list of key-value pairs
+                                            (key1=value1,key2=value2) or in JSON
+                                            format.
+
+Arguments replace-vars and set-vars are mutually exclusive
+
+`
+
+exports['flex update by specifying a profile when valid project is set with invalid basic env vars (set) should fail 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'primaryProfile'
+kinvey flex update
+
+Update environment variables
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --service                                 Service ID                  [string]
+  --replace-vars                            Environment variables (replaces all
+                                            already existing). Specify either as
+                                            comma-separated list of key-value
+                                            pairs (key1=value1,key2=value2) or
+                                            in JSON format.
+  --set-vars                                Environment variables to set.
+                                            Specify either as comma-separated
+                                            list of key-value pairs
+                                            (key1=value1,key2=value2) or in JSON
+                                            format.
+
+Environment variables must be specified as comma-separated list where key=value or in valid JSON format.
+
+`
+
 exports['flex update by specifying a profile when valid project is set with valid basic env vars (replace) should succeed and output default format 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'primaryProfile'
@@ -24,115 +117,6 @@ exports['flex update by specifying a profile when valid project is set with vali
 
 `
 
-exports['flex update by specifying a profile when valid project is set with invalid basic env vars (set) should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'primaryProfile'
-kinvey flex update
-
-Update environment variables
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --service                 Service ID                                  [string]
-  --replace-vars            Environment variables (replaces all already
-                            existing). Specify either as comma-separated list of
-                            key-value pairs (key1=value1,key2=value2) or in JSON
-                            format.
-  --set-vars                Environment variables to set. Specify either as
-                            comma-separated list of key-value pairs
-                            (key1=value1,key2=value2) or in JSON format.
-
-Environment variables must be specified as comma-separated list where key=value or in valid JSON format.
-
-`
-
-exports['flex update by specifying a profile when valid project is set with both set and replace env vars should fail 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'primaryProfile'
-kinvey flex update
-
-Update environment variables
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --service                 Service ID                                  [string]
-  --replace-vars            Environment variables (replaces all already
-                            existing). Specify either as comma-separated list of
-                            key-value pairs (key1=value1,key2=value2) or in JSON
-                            format.
-  --set-vars                Environment variables to set. Specify either as
-                            comma-separated list of key-value pairs
-                            (key1=value1,key2=value2) or in JSON format.
-
-Arguments replace-vars and set-vars are mutually exclusive
-
-`
-
-exports['flex update by specifying a profile when invalid project is set with existent service as an option and single env var (set) should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'primaryProfile'
-[debug] Request:  GET http://localhost:3234/v2/data-links/0de22ffb3f2243ec8138170844envVar
-[debug] Response: GET http://localhost:3234/v2/data-links/0de22ffb3f2243ec8138170844envVar 200
-[debug] Request:  PUT http://localhost:3234/v2/data-links/0de22ffb3f2243ec8138170844envVar
-[debug] Response: PUT http://localhost:3234/v2/data-links/0de22ffb3f2243ec8138170844envVar 200
-Updated service: 0de22ffb3f2243ec8138170844envVar
-
-`
-
-exports['flex update by specifying credentials without service should fail 1'] = `
-[debug] Checking for package updates
-kinvey flex update
-
-Update environment variables
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-  --service                 Service ID                                  [string]
-  --replace-vars            Environment variables (replaces all already
-                            existing). Specify either as comma-separated list of
-                            key-value pairs (key1=value1,key2=value2) or in JSON
-                            format.
-  --set-vars                Environment variables to set. Specify either as
-                            comma-separated list of key-value pairs
-                            (key1=value1,key2=value2) or in JSON format.
-
-This project is not configured. Use 'kinvey flex init' to get started. Alternatively, use options: service.
-
-`
-
 exports['flex update by specifying credentials with service and valid complex env vars (set) should succeed 1'] = `
 [debug] Checking for package updates
 [debug] Logging in user: janeyDoe@mail.com
@@ -146,5 +130,45 @@ exports['flex update by specifying credentials with service and valid complex en
 [debug] Response: DELETE http://localhost:3234/session 204
 [debug] Logged out current user.
 Updated service: 0de22ffb3f2243ec8138170844envVar
+
+`
+
+exports['flex update by specifying credentials without service should fail 1'] = `
+[debug] Checking for package updates
+kinvey flex update
+
+Update environment variables
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+  --service                                 Service ID                  [string]
+  --replace-vars                            Environment variables (replaces all
+                                            already existing). Specify either as
+                                            comma-separated list of key-value
+                                            pairs (key1=value1,key2=value2) or
+                                            in JSON format.
+  --set-vars                                Environment variables to set.
+                                            Specify either as comma-separated
+                                            list of key-value pairs
+                                            (key1=value1,key2=value2) or in JSON
+                                            format.
+
+This project is not configured. Use 'kinvey flex init' to get started. Alternatively, use options: service.
 
 `

--- a/__snapshots__/profile-create.test.js
+++ b/__snapshots__/profile-create.test.js
@@ -1,34 +1,100 @@
-exports['profile create with valid credentials set as options should create 1'] = `
-[debug] Checking for package updates
-[debug] Logging in user: janeDoe@mail.com
-[debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 200
-[debug] Writing contents to file globalSetupPath
-Created profile: testProfile
+exports['profile create with insufficient info with too many args should fail 1'] = `
+kinvey profile create <name>
+
+Create profile
+
+Positionals:
+  name  Profile name                                                  [required]
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+
+Too many non-option arguments: got 1, maximum of 0
 
 `
 
-exports['profile create with valid credentials set as options and valid 2fa token should create 1'] = `
+exports['profile create with insufficient info without 2fa token when required should fail 1'] = `
 [debug] Checking for package updates
 [debug] Logging in user: janeDoe@mail.com
 [debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 200
-[debug] Writing contents to file globalSetupPath
-Created profile: testProfile
+[debug] Response: POST http://localhost:3234/session 403
+[warn] Two-factor authentication token is required. Please specify '2fa' option or use 'kinvey init' to create a profile.
+[error] InvalidTwoFactorAuth: Two-factor authentication is required, but a token was missing from your request.
 
 `
 
-exports['profile create with valid credentials set as options and existent profile name should override 1'] = `
+exports['profile create with insufficient info without password should fail 1'] = `
+[debug] Checking for package updates
+[debug] Logging in user: johnDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 422
+[error] ValidationError: Validation failed. Missing required property: password
+
+`
+
+exports['profile create with insufficient info without profile name should fail 1'] = `
+kinvey profile create <name>
+
+Create profile
+
+Positionals:
+  name  Profile name                                                  [required]
+
+Options:
+  --version                                 Show version number        [boolean]
+  --email                                   E-mail address of your Kinvey
+                                            account                     [string]
+  --password                                Password of your Kinvey account
+                                                                        [string]
+  --2fa, --2Fa                              Two-factor authentication token
+                                                                        [string]
+  --instance-id, --instanceId               Instance ID                 [string]
+  --profile                                 Profile to use              [string]
+  --output                                  Output format
+                                                      [string] [choices: "json"]
+  --silent                                  Do not output anything     [boolean]
+  --suppress-version-check,                 Do not check for package updates
+  --suppressVersionCheck                                               [boolean]
+  --verbose                                 Output debug messages      [boolean]
+  --no-color, --noColor                     Disable colors             [boolean]
+  -h, --help                                Show help                  [boolean]
+
+Not enough non-option arguments: got 0, need at least 1
+
+`
+
+exports['profile create with invalid credentials set as options should fail 1'] = `
+[debug] Checking for package updates
+[debug] Logging in user: johnDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 401
+[error] InvalidCredentials: Credentials are invalid. Please authenticate.
+
+`
+
+exports['profile create with invalid credentials set as options when trying to override should fail 1'] = `
 [debug] Checking for package updates
 [debug] Overriding profile with name 'testProfile'.
-[debug] Logging in user: janeDoe@mail.com
+[debug] Logging in user: johnDoe@mail.com
 [debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 200
-[debug] Request:  DELETE http://localhost:3234/session
-[debug] Response: DELETE http://localhost:3234/session 204
-[debug] Logged out current user.
-[debug] Writing contents to file globalSetupPath
-Created profile: testProfile
+[debug] Response: POST http://localhost:3234/session 401
+[error] InvalidCredentials: Credentials are invalid. Please authenticate.
 
 `
 
@@ -60,16 +126,6 @@ exports['profile create with valid credentials set as environment variables when
 
 `
 
-exports['profile create with valid credentials set as options and as environment variables should create 1'] = `
-[debug] Checking for package updates
-[debug] Logging in user: janeDoe@mail.com
-[debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 200
-[debug] Writing contents to file globalSetupPath
-Created profile: testProfile
-
-`
-
 exports['profile create with valid credentials set as options + host should create 1'] = `
 [debug] Checking for package updates
 [debug] Logging in user: janeDoe@mail.com
@@ -80,92 +136,46 @@ Created profile: testProfile
 
 `
 
-exports['profile create with invalid credentials set as options should fail 1'] = `
-[debug] Checking for package updates
-[debug] Logging in user: johnDoe@mail.com
-[debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 401
-[error] InvalidCredentials: Credentials are invalid. Please authenticate.
-
-`
-
-exports['profile create with invalid credentials set as options when trying to override should fail 1'] = `
-[debug] Checking for package updates
-[debug] Overriding profile with name 'testProfile'.
-[debug] Logging in user: johnDoe@mail.com
-[debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 401
-[error] InvalidCredentials: Credentials are invalid. Please authenticate.
-
-`
-
-exports['profile create with insufficient info without password should fail 1'] = `
-[debug] Checking for package updates
-[debug] Logging in user: johnDoe@mail.com
-[debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 422
-[error] ValidationError: Validation failed. Missing required property: password
-
-`
-
-exports['profile create with insufficient info without profile name should fail 1'] = `
-kinvey profile create <name>
-
-Create profile
-
-Positionals:
-  name  Profile name                                                  [required]
-
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
-
-Not enough non-option arguments: got 0, need at least 1
-
-`
-
-exports['profile create with insufficient info without 2fa token when required should fail 1'] = `
+exports['profile create with valid credentials set as options and as environment variables should create 1'] = `
 [debug] Checking for package updates
 [debug] Logging in user: janeDoe@mail.com
 [debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 403
-[warn] Two-factor authentication token is required. Please specify '2fa' option or use 'kinvey init' to create a profile.
-[error] InvalidTwoFactorAuth: Two-factor authentication is required, but a token was missing from your request.
+[debug] Response: POST http://localhost:3234/session 200
+[debug] Writing contents to file globalSetupPath
+Created profile: testProfile
 
 `
 
-exports['profile create with insufficient info with too many args should fail 1'] = `
-kinvey profile create <name>
+exports['profile create with valid credentials set as options and existent profile name should override 1'] = `
+[debug] Checking for package updates
+[debug] Overriding profile with name 'testProfile'.
+[debug] Logging in user: janeDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 200
+[debug] Request:  DELETE http://localhost:3234/session
+[debug] Response: DELETE http://localhost:3234/session 204
+[debug] Logged out current user.
+[debug] Writing contents to file globalSetupPath
+Created profile: testProfile
 
-Create profile
+`
 
-Positionals:
-  name  Profile name                                                  [required]
+exports['profile create with valid credentials set as options and valid 2fa token should create 1'] = `
+[debug] Checking for package updates
+[debug] Logging in user: janeDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 200
+[debug] Writing contents to file globalSetupPath
+Created profile: testProfile
 
-Options:
-  --version                 Show version number                        [boolean]
-  --email                   E-mail address of your Kinvey account       [string]
-  --password                Password of your Kinvey account             [string]
-  --2fa, --2Fa              Two-factor authentication token             [string]
-  --instance-id             Instance ID                                 [string]
-  --profile                 Profile to use                              [string]
-  --output                  Output format             [string] [choices: "json"]
-  --silent                  Do not output anything                     [boolean]
-  --suppress-version-check  Do not check for package updates           [boolean]
-  --verbose                 Output debug messages                      [boolean]
-  --no-color                Disable colors                             [boolean]
-  -h, --help                Show help                                  [boolean]
+`
 
-Too many non-option arguments: got 1, maximum of 0
+exports['profile create with valid credentials set as options should create 1'] = `
+[debug] Checking for package updates
+[debug] Logging in user: janeDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 200
+[debug] Writing contents to file globalSetupPath
+Created profile: testProfile
 
 `

--- a/lib/CLIManager.js
+++ b/lib/CLIManager.js
@@ -280,6 +280,7 @@ class CLIManager {
       .option(
         AuthOptionsNames.HOST, {
           global: true,
+          alias: 'instanceId',
           describe: 'Instance ID',
           type: 'string'
         }
@@ -309,6 +310,7 @@ class CLIManager {
       .option(
         CommonOptionsNames.SUPPRESS_VERSION_CHECK, {
           global: true,
+          alias: 'suppressVersionCheck',
           describe: 'Do not check for package updates',
           type: 'boolean'
         }
@@ -320,6 +322,7 @@ class CLIManager {
       })
       .option(CommonOptionsNames.NO_COLOR, {
         global: true,
+        alias: 'noColor',
         describe: 'Disable colors',
         type: 'boolean'
       })

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -89,6 +89,7 @@ Constants.CommonOptionsNames = {
 Constants.CommonOptions = {
   [Constants.CommonOptionsNames.NO_PROMPT]: {
     global: false,
+    alias: 'noPrompt',
     describe: 'Do not prompt',
     type: 'boolean',
     default: false


### PR DESCRIPTION
Add aliases for the following options:

- `instance-id` = `instanceId`
- `no-prompt` = `noPrompt`
- `no-color` = `noColor`
- `suppress-version-check` = `suppressVersionCheck`

Without these aliases and when `camel-case-expansion` is false, these options cannot be set as environment variables. The CLI errors out because yargs parses them to camel case but then it can't recognize them.