### PR TITLE
CLI-165: Fix env vars on deploy

### DIFF
--- a/lib/flex/FlexController.js
+++ b/lib/flex/FlexController.js
@@ -282,7 +282,7 @@ class FlexController extends BaseController {
           return setImmediate(next);
         }
 
-        this.flexService.getServiceById(serviceId, (err, data) => {
+        this.flexService.getSpecifiedOrDefaultSvcEnv(serviceId, this._metadata.svcEnvId, (err, data) => {
           if (err) {
             return next(err);
           }


### PR DESCRIPTION
Preserve existing env vars on `flex deploy --set-vars <env-vars-to-set>`.