### PR TITLE
Cli 136 test app export

### DIFF
--- a/lib/exporter/AppFileExporter.js
+++ b/lib/exporter/AppFileExporter.js
@@ -125,7 +125,7 @@ class AppFileExporter {
 
     async.waterfall([
       (next) => {
-        this.servicesService.getAllByDomainType(options.app, false, next);
+        this.servicesService.getAllOnAppLevel(options.app.id, false, next);
       },
       (services, next) => {
         async.eachSeries(

--- a/lib/service/ServicesService.js
+++ b/lib/service/ServicesService.js
@@ -51,6 +51,25 @@ class ServicesService extends BaseService {
   }
 
   /**
+   * Gets all services owned by the specified app.
+   * @param {String} appId
+   * @param {Boolean} shouldExpand If true, the services envs will be included in the result.
+   * @param done
+   */
+  getAllOnAppLevel(appId, shouldExpand, done) {
+    const query = {
+      appId
+    };
+
+    if (shouldExpand) {
+      query.expand = 'environments';
+    }
+
+    const endpoint = Endpoints.services(this.cliManager.config.defaultSchemaVersion);
+    this.cliManager.sendRequest({ endpoint, query }, done);
+  }
+
+  /**
    * Gets all the internal services (sorted) for a domain. Returns error if none found.
    * @param {Object} entity Backend app or org.
    * @param done

--- a/test/ConfigManagementHelper.js
+++ b/test/ConfigManagementHelper.js
@@ -52,6 +52,26 @@ function passConfigFileToCli(cmd, configContent, filePath, done) {
   });
 }
 
+function exportEntityAsJson(cmd, done) {
+  const fileName = `${TestsHelper.randomStrings.plainString(10)}.json`;
+  const filePath = path.join(TestsHelper.ConfigFilesDir, fileName);
+  const finalCmd = `${cmd} ${filePath} --output json`;
+
+  TestsHelper.execCmdWoMocks(finalCmd, null, (err) => {
+    if (err) {
+      return done(err);
+    }
+
+    fs.readFile(filePath, null, (err, data) => {
+      if (err) {
+        return done(err);
+      }
+
+      done(null, JSON.parse(data));
+    });
+  });
+}
+
 const service = {};
 service.createPackageJsonForFlexProject = function createPackageJsonForFlexProject(pkgJson, done) {
   if (!pkgJson) {
@@ -887,6 +907,15 @@ app.assertApp = function assertApp({ config, id, orgIdentifier, expectedName, ex
   ], done);
 };
 
+app.exportApp = function exportApp(appIdentifier, done) {
+  let cmd = 'app export';
+  if (appIdentifier) {
+    cmd = `${cmd} --app ${appIdentifier}`;
+  }
+
+  exportEntityAsJson(cmd, done);
+};
+
 const roles = {};
 roles.buildValidRolesList = function buildValidRolesList(count) {
   const result = [];
@@ -902,26 +931,12 @@ roles.buildValidRolesList = function buildValidRolesList(count) {
 
 const org = {};
 org.exportOrg = function exportOrg(orgIdentifier, done) {
-  const fileName = `${TestsHelper.randomStrings.plainString(10)}.json`;
-  const filePath = path.join(TestsHelper.ConfigFilesDir, fileName);
-  let cmd = `org export ${filePath} --output json`;
+  let cmd = 'org export';
   if (orgIdentifier) {
     cmd = `${cmd} --org ${orgIdentifier}`;
   }
 
-  TestsHelper.execCmdWoMocks(cmd, null, (err) => {
-    if (err) {
-      return done(err);
-    }
-
-    fs.readFile(filePath, null, (err, data) => {
-      if (err) {
-        return done(err);
-      }
-
-      done(null, JSON.parse(data));
-    });
-  });
+  exportEntityAsJson(cmd, done);
 };
 
 service.assertFlexSvcEnv = function assertFlexSvcEnv(actual, expected, serviceType) {

--- a/test/integration-no-mock/config-management/app-config-export.js
+++ b/test/integration-no-mock/config-management/app-config-export.js
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) 2018, Kinvey, Inc. All rights reserved.
+ *
+ * This software is licensed to you under the Kinvey terms of service located at
+ * http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+ * software, you hereby accept such terms of service  (and any agreement referenced
+ * therein) and agree that you have read, understand and agree to be bound by such
+ * terms of service and are of legal age to agree to such terms with Kinvey.
+ *
+ * This software contains valuable confidential and proprietary information of
+ * KINVEY, INC and is subject to applicable licensing agreements.
+ * Unauthorized reproduction, transmission or distribution of this file and its
+ * contents is a violation of applicable laws.
+ */
+
+const async = require('async');
+
+const ConfigFileProcessor = require('./../../../lib/ConfigFileProcessor');
+const ConfigManagementHelper = require('./../../ConfigManagementHelper');
+const { ConfigFilesDir, execCmdWoMocks, randomStrings } = require('./../../TestsHelper');
+
+const orgToUse = 'CliOrg';
+
+function exportAppWithResolvedFileRefs(appIdentifier, done) {
+  ConfigManagementHelper.app.exportApp(appIdentifier, (err, result) => {
+    if (err) {
+      return done(err);
+    }
+
+    ConfigFileProcessor._processConfigFileValue(result, ConfigFilesDir, '', done);
+  });
+}
+
+module.exports = () => {
+  let appName;
+
+  afterEach('remove app', (done) => {
+    execCmdWoMocks(`app delete --app ${appName} --no-prompt`, null, (err) => {
+      appName = null;
+      done(err);
+    });
+  });
+
+  describe('basic app', () => {
+    const testForBasicAppWithDefaultEnv = (orgIdentifier, done) => {
+      let exportedApp;
+      let appId;
+      appName = randomStrings.appName();
+
+      const config = {
+        schemaVersion: '1.0.0',
+        configType: 'application',
+        settings: {
+          realtime: {
+            enabled: true
+          },
+          sessionTimeoutInSeconds: 200
+        }
+      };
+
+      async.series([
+        (next) => {
+          ConfigManagementHelper.app.createFromConfig(appName, config, orgIdentifier, (err, id) => {
+            if (err) {
+              return next(err);
+            }
+
+            appId = id;
+            next();
+          });
+        },
+        (next) => {
+          exportAppWithResolvedFileRefs(appName, (err, data) => {
+            if (err) {
+              return next(err);
+            }
+
+            exportedApp = data;
+            next();
+          });
+        },
+        (next) => {
+          const expectedConfig = Object.assign({}, config);
+          expectedConfig.environments = {
+            Development: {
+              configType: 'environment',
+              schemaVersion: '1.0.0',
+              settings: {
+                apiVersion: 3
+              },
+              collections: {
+                _blob: {
+                  type: 'internal',
+                  permissions: 'shared'
+                },
+                user: {
+                  type: 'internal',
+                  permissions: 'shared'
+                }
+              }
+            }
+          };
+          expectedConfig.services = {};
+
+          expect(exportedApp).to.deep.equal(expectedConfig);
+          next();
+        }
+      ], done);
+    };
+
+    it('outside of an org with default env  should succeed', (done) => {
+      testForBasicAppWithDefaultEnv(null, done);
+    });
+
+    it('inside an org with default env should succeed', (done) => {
+      testForBasicAppWithDefaultEnv('CliOrg', done);
+    });
+  });
+
+  describe('complex app', () => {
+    const orgServicesToRemove = [];
+
+    after('remove services', (done) => {
+      async.each(
+        orgServicesToRemove,
+        (currSvcId, next) => {
+          ConfigManagementHelper.testHooks.removeService(currSvcId, next);
+        },
+        done
+      );
+    });
+
+    it('inside an org with own services and external collections should succeed', (done) => {
+      let exportedApp;
+      let appId;
+      let appConfig;
+
+      const orgSvcEnvName = `orgEnv${randomStrings.plainString(4)}`;
+      const orgServiceName = `org${randomStrings.plainString()}`;
+
+      async.series([
+        (next) => {
+          // create org-level service to verify later on that only app-level services are exported
+          const serviceConfig = {
+            configType: 'service',
+            schemaVersion: '1.0.0',
+            type: 'flex-internal',
+            description: 'Test service',
+            environments: {
+              [orgSvcEnvName]: {
+                secret: '123'
+              }
+            }
+          };
+
+          ConfigManagementHelper.service.createFromConfig(orgServiceName, serviceConfig, 'org', orgToUse, null, (err, id) => {
+            if (err) {
+              return next(err);
+            }
+
+            orgServicesToRemove.push(id);
+            next();
+          });
+        },
+        (next) => {
+          // create an app with external collections and a service
+          const appServiceName = `app${randomStrings.plainString(6)}`;
+          const appSvcEnvName = `appEnv${randomStrings.plainString(4)}`;
+          const appServiceConfig = {
+            configType: 'service',
+            schemaVersion: '1.0.0',
+            type: 'flex-internal',
+            description: 'Test service',
+            environments: {
+              [appSvcEnvName]: {
+                secret: '45678'
+              },
+              devEnv: {
+                secret: 'secret0'
+              }
+            }
+          };
+          const collList = [ConfigManagementHelper.env.buildExternalCollection(appServiceName, appSvcEnvName, 'MyCollection', randomStrings.collName())];
+          const prodColls = ConfigManagementHelper.common.buildConfigEntityFromList(collList);
+          const prodEnv = {
+            schemaVersion: '1.0.0',
+            settings: ConfigManagementHelper.env.buildSettings(),
+            collections: prodColls
+          };
+
+          appConfig = {
+            schemaVersion: '1.0.0',
+            configType: 'application',
+            settings: { sessionTimeoutInSeconds: 60 },
+            environments: {
+              dev: {
+                schemaVersion: '1.0.0',
+                settings: ConfigManagementHelper.env.buildSettings()
+              },
+              prod: prodEnv
+            },
+            services: {
+              [appServiceName]: appServiceConfig
+            }
+          };
+
+          appName = randomStrings.appName();
+          ConfigManagementHelper.app.createFromConfig(appName, appConfig, orgToUse, (err, id) => {
+            if (err) {
+              return next(err);
+            }
+
+            appId = id;
+            next();
+          });
+        },
+        (next) => {
+          exportAppWithResolvedFileRefs(appName, (err, data) => {
+            if (err) {
+              return next(err);
+            }
+
+            exportedApp = data;
+            next();
+          });
+        },
+        (next) => {
+          // add the system collections
+          const expectedConfig = Object.assign({}, appConfig);
+          Object.keys(expectedConfig.environments).forEach((appEnv) => {
+            expectedConfig.environments[appEnv].configType = 'environment';
+            const systemColls = ['_blob', 'user'];
+            if (!expectedConfig.environments[appEnv].collections) {
+              expectedConfig.environments[appEnv].collections = {};
+            }
+
+            systemColls.forEach((sysColl) => {
+              expectedConfig.environments[appEnv].collections[sysColl] = {
+                type: 'internal',
+                permissions: 'shared'
+              };
+            });
+          });
+
+          expect(exportedApp).to.deep.equal(expectedConfig);
+          next();
+        }
+      ], done);
+    });
+  });
+};

--- a/test/integration-no-mock/config-management/config-management.test.js
+++ b/test/integration-no-mock/config-management/config-management.test.js
@@ -21,6 +21,7 @@ const { ConfigFilesDir } = require('./../../TestsHelper');
 
 const appConfigCreateTests = require('./app-config-create');
 const appConfigPushTests = require('./app-config-push');
+const appConfigExportTests = require('./app-config-export');
 const envConfigCreateTests = require('./env-config-create');
 const envConfigPushTests = require('./env-config-push');
 const envConfigExportTests = require('./env-config-export');
@@ -83,6 +84,8 @@ describe('Config management', () => {
   describe('App config create', appConfigCreateTests);
 
   describe('App config push', appConfigPushTests);
+
+  describe('App config export', appConfigExportTests);
 
   describe('Env config create', envConfigCreateTests);
 


### PR DESCRIPTION
Test 'app export'
Fix 'app export' to export only app-owned services

*Note:* Branch based on 'cli-138-v3-api-migration-ea-config'. Should be reviewed after PR #150 gets merged.