### PR TITLE
META-346: Validate pages on deploy; add force flag

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -307,7 +307,7 @@ Constants.SitesOptions = {
   },
   [Constants.SitesOptionsNames.FORCE]: {
     global: false,
-    describe: 'Force execution (skip validation)',
+    describe: 'Force execution (skip client-side validation)',
     type: 'boolean',
     demandOption: false,
     default: false

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -269,7 +269,8 @@ Constants.SitesOptionsNames = {
   DOMAIN_NAME: 'domainName',
   INDEX_PAGE: 'indexPage',
   ERROR_PAGE: 'errorPage',
-  ROUTING: 'historyApiRouting'
+  ROUTING: 'historyApiRouting',
+  FORCE: 'force'
 };
 
 Constants.SitesOptions = {
@@ -300,6 +301,13 @@ Constants.SitesOptions = {
   [Constants.SitesOptionsNames.ROUTING]: {
     global: false,
     describe: 'Enable server support for History API routing',
+    type: 'boolean',
+    demandOption: false,
+    default: false
+  },
+  [Constants.SitesOptionsNames.FORCE]: {
+    global: false,
+    describe: 'Force execution (skip validation)',
     type: 'boolean',
     demandOption: false,
     default: false

--- a/lib/website/SiteEnvsService.js
+++ b/lib/website/SiteEnvsService.js
@@ -14,6 +14,7 @@
  */
 
 const fs = require('fs');
+const { EOL } = require('os');
 const path = require('path');
 
 const BaseService = require('./../BaseService');
@@ -82,17 +83,17 @@ class SiteEnvsService extends BaseService {
     }
 
     if (!foundIndexPage || !foundErrorPage) {
-      let errMsg = 'One or more pages not found.';
+      let errMsg = 'Required file(s) not found.';
 
       if (!foundIndexPage) {
-        errMsg = `${errMsg} Index page: '${indexPage}'.`;
+        errMsg = `${errMsg}${EOL}\tIndex page: '${indexPage}'.`;
       }
 
       if (!foundErrorPage) {
-        errMsg = `${errMsg} Error page: '${errorPage}'.`;
+        errMsg = `${errMsg}${EOL}\tError page: '${errorPage}'.`;
       }
 
-      const err = new KinveyError('PagesNotFound', errMsg);
+      const err = new KinveyError('FilesNotFound', errMsg);
       return setImmediate(() => { done(err); });
     }
 

--- a/lib/website/SiteEnvsService.js
+++ b/lib/website/SiteEnvsService.js
@@ -35,15 +35,27 @@ class SiteEnvsService extends BaseService {
   /**
    * Passes to callback appropriate form data for site deploy from relative or absolute path.
    * @param {String} initialPath Relative or absolute path.
+   * @param {String|null} indexPage Index page name, e.g. 'index.html'.
+   * @param {String|null} errorPage Error page name.
    * @param done
    */
-  static buildFormData(initialPath, done) {
+  static buildFormData(initialPath, indexPage, errorPage, done) {
     const result = {};
+    let foundIndexPage = isNullOrUndefined(indexPage);
+    let foundErrorPage = isNullOrUndefined(errorPage);
 
     let traversePath;
     traversePath = (currPath, relativePathToInitialTarget) => { // eslint-disable-line
       if (fs.lstatSync(currPath).isFile()) {
         const key = relativePathToInitialTarget || path.basename(currPath);
+        if (!foundIndexPage && key === indexPage) {
+          foundIndexPage = true;
+        }
+
+        if (!foundErrorPage && key === errorPage) {
+          foundErrorPage = true;
+        }
+
         result[key] = fs.createReadStream(currPath);
         return;
       }
@@ -69,11 +81,26 @@ class SiteEnvsService extends BaseService {
       return setImmediate(() => { done(ex); });
     }
 
+    if (!foundIndexPage || !foundErrorPage) {
+      let errMsg = 'One or more pages not found.';
+
+      if (!foundIndexPage) {
+        errMsg = `${errMsg} Index page: '${indexPage}'.`;
+      }
+
+      if (!foundErrorPage) {
+        errMsg = `${errMsg} Error page: '${errorPage}'.`;
+      }
+
+      const err = new KinveyError('PagesNotFound', errMsg);
+      return setImmediate(() => { done(err); });
+    }
+
     return setImmediate(() => { done(null, result); });
   }
 
-  deploy({ siteId, siteEnvId, targetPath }, done) {
-    SiteEnvsService.buildFormData(targetPath, (err, formData) => {
+  deploy({ siteId, siteEnvId, targetPath, indexPage, errorPage }, done) {
+    SiteEnvsService.buildFormData(targetPath, indexPage, errorPage, (err, formData) => {
       if (err) {
         return done(err);
       }

--- a/lib/website/SitesController.js
+++ b/lib/website/SitesController.js
@@ -209,6 +209,7 @@ class SitesController extends BaseController {
     const siteIdentifier = options[SitesOptionsNames.SITE];
     let siteId;
     let siteEnvId;
+    let siteEnv;
 
     async.series([
       (next) => {
@@ -217,14 +218,26 @@ class SitesController extends BaseController {
             return next(err);
           }
 
-          ({ siteId, siteEnvId } = data);
+          ({ siteId, siteEnvId, siteEnv } = data);
           next();
         });
       },
       (next) => {
+        let indexPage;
+        let errorPage;
+
+        if (!options[SitesOptionsNames.FORCE]) {
+          indexPage = siteEnv.options.indexPage;
+          if (!siteEnv.options.historyApiRouting) {
+            errorPage = siteEnv.options.errorPage;
+          }
+        }
+
         const deployOpts = {
           siteId,
           siteEnvId,
+          indexPage,
+          errorPage,
           targetPath: options.path
         };
 
@@ -290,7 +303,6 @@ class SitesController extends BaseController {
       if (err) {
         if (err.name === 'InvalidSiteEnvironment') {
           return done(new KinveyError('InvalidAction', 'No files have been deployed yet.'));
-          // return done();
         }
 
         return done(err);

--- a/lib/website/sitesRouter.js
+++ b/lib/website/sitesRouter.js
@@ -60,7 +60,8 @@ const cmdDefinitions = [
           type: 'string',
           description: 'Path to file or directory',
           required: true
-        });
+        })
+        .option(SitesOptionsNames.FORCE, SitesOptions[SitesOptionsNames.FORCE]);
     },
     handlerName: 'deploy',
     requirements: [CommandRequirement.AUTH]

--- a/test/unit/lib/site-envs-service.test.js
+++ b/test/unit/lib/site-envs-service.test.js
@@ -15,6 +15,7 @@
 
 const sinon = require('sinon');
 
+const { EOL } = require('os');
 const fs = require('fs');
 const path = require('path');
 
@@ -98,8 +99,8 @@ describe('SiteEnvsService', () => {
       const expectedIndexPage = 'main.html';
       SiteEnvsService.buildFormData(pathToTarget, expectedIndexPage, null, (err) => {
         expect(err).to.exist;
-        expect(err.name).to.equal('PagesNotFound');
-        expect(err.message).to.equal(`One or more pages not found. Index page: '${expectedIndexPage}'.`);
+        expect(err.name).to.equal('FilesNotFound');
+        expect(err.message).to.equal(`Required file(s) not found.${EOL}\tIndex page: '${expectedIndexPage}'.`);
 
         done();
       });
@@ -110,8 +111,8 @@ describe('SiteEnvsService', () => {
       const expectedErrorPage = 'my-error.html';
       SiteEnvsService.buildFormData(pathToTarget, indexPageDefault, expectedErrorPage, (err) => {
         expect(err).to.exist;
-        expect(err.name).to.equal('PagesNotFound');
-        expect(err.message).to.equal(`One or more pages not found. Error page: '${expectedErrorPage}'.`);
+        expect(err.name).to.equal('FilesNotFound');
+        expect(err.message).to.equal(`Required file(s) not found.${EOL}\tError page: '${expectedErrorPage}'.`);
 
         done();
       });
@@ -123,8 +124,8 @@ describe('SiteEnvsService', () => {
       const expectedErrorPage = 'my-error.html';
       SiteEnvsService.buildFormData(pathToTarget, expectedIndexPage, expectedErrorPage, (err) => {
         expect(err).to.exist;
-        expect(err.name).to.equal('PagesNotFound');
-        const expErrMsg = `One or more pages not found. Index page: '${expectedIndexPage}'. Error page: '${expectedErrorPage}'.`;
+        expect(err.name).to.equal('FilesNotFound');
+        const expErrMsg = `Required file(s) not found.${EOL}\tIndex page: '${expectedIndexPage}'.${EOL}\tError page: '${expectedErrorPage}'.`;
         expect(err.message).to.equal(expErrMsg);
 
         done();


### PR DESCRIPTION
`website deploy`

Validate that indexPage and errorPage are actually present in the files that are about to be uploaded. 
Return error if not. Error example: 
`[error] PagesNotFound: One or more pages not found. Index page: 'index.html'. Error page: 'error.html'.`

Add a `--force` flag to the command. Default value: `false`. On `website deploy --force` pages validation is skipped.