### PR TITLE
META-164: Improve error response handling

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -115,6 +115,23 @@ class Request {
     }
   }
 
+  static _getDebugMessage(debug) {
+    if (Utils.isNullOrUndefined(debug)) {
+      return '';
+    }
+
+    let debugMsg = '';
+    if (debug.message) {
+      debugMsg = debug.message;
+    } else if (typeof debug === 'string') {
+      debugMsg = debug;
+    } else if (typeof debug === 'object') {
+      debugMsg = JSON.stringify(debug);
+    }
+
+    return debugMsg;
+  }
+
   static _getProcessedError(err, response) {
     const isSuccess = !err && response && response.statusCode >= 200 && response.statusCode < 300;
     if (isSuccess) {
@@ -128,8 +145,8 @@ class Request {
     // status is not 2xx
     if (response.body) {
       let errMsg = response.body.description || '';
-      if (!Utils.isNullOrUndefined(response.body.debug)) {
-        const debugMsg = response.body.debug.message || response.body.debug;
+      const debugMsg = Request._getDebugMessage(response.body.debug);
+      if (debugMsg) {
         errMsg += ` ${debugMsg}`;
       }
 

--- a/test/unit/lib/request.test.js
+++ b/test/unit/lib/request.test.js
@@ -197,6 +197,75 @@ describe('Request', () => {
       });
     });
 
+    const testCases = [
+      {
+        title: 'there is debug property (string)',
+        backendErr: {
+          code: 'SiteInternalError',
+          description: 'Some error.',
+          debug: 'Additional info.'
+        },
+        expectedErr: {
+          name: 'SiteInternalError',
+          message: 'Some error. Additional info.'
+        }
+      },
+      {
+        title: 'there is no debug property',
+        backendErr: {
+          code: 'CannotDeleteEnvironment',
+          description: 'The specified environment cannot be deleted.'
+        },
+        expectedErr: {
+          name: 'CannotDeleteEnvironment',
+          message: 'The specified environment cannot be deleted.'
+        }
+      },
+      {
+        title: 'there is debug property (Error)',
+        backendErr: {
+          code: 'SiteInternalError',
+          description: 'Some error.',
+          debug: new Error('Test error.')
+        },
+        expectedErr: {
+          name: 'SiteInternalError',
+          message: 'Some error. Test error.'
+        }
+      },
+      {
+        title: 'there is debug property (object)',
+        backendErr: {
+          code: 'SiteInternalError',
+          description: 'Some error.',
+          debug: {
+            someProperty: 'test'
+          }
+        },
+        expectedErr: {
+          name: 'SiteInternalError',
+          message: 'Some error. {"someProperty":"test"}'
+        }
+      }
+    ];
+
+    testCases.forEach((t) => {
+      it(`when response is 400 ${t.title} should return response and error`, (done) => {
+        const noSuccessRes = {
+          statusCode: 400,
+          body: t.backendErr,
+          rawTrailers: [],
+          upgrade: false
+        };
+        reqStub.yields(null, noSuccessRes);
+        reqObj.send((err, res) => {
+          assertions.assertError(err, t.expectedErr);
+          expect(res).to.deep.equal(noSuccessRes);
+          done();
+        });
+      });
+    });
+
     it('when a connection error occurs should return empty response and error', (done) => {
       const connErr = new Error(Errors.RequestTimedOut.NAME);
       connErr.code = Errors.RequestTimedOut.NAME;


### PR DESCRIPTION
When response is 4xx sometimes there's a `debug` property that contains more info. It is a string in most cases, but it could also be an instance of Error or just an object.