### PR TITLE
Fix small config management bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,7 +851,7 @@ Kinvey CLI supports the usage of configuration files (JSON format) to enable con
 
 **Environments** can be created and modified by applying an environment configuration file. The file can contain: environment-related settings, collections, business logic, roles, push settings.
 
-**Services** can be created and modified by applying a service configuration file. Supported services: internal flex, external flex, REST, Sharepoint, Salesforce, MS SQL, SAP, ProgressData, DataDirect, Rapid health.
+**Services** can be created and modified by applying a service configuration file. Supported services: internal flex, external flex, REST, Sharepoint, Salesforce, MS SQL, ProgressData, DataDirect, Rapid health.
 
 ### Environment configuration file
 
@@ -1143,7 +1143,7 @@ The following service template can be used and modified as needed:
 
 `configType` *environment|service* The configuration type. Required.
 
-`type` *flex-internal|flex-external|rest|sharepoint|salesforce|mssql|sap|progressData|dataDirect|rapid-health* Service type. Required.
+`type` *flex-internal|flex-external|rest|sharepoint|salesforce|mssql|progressData|dataDirect|rapid-health* Service type. Required.
  
 `description` Service description. String. Optional.
  

--- a/__snapshots__/app-create.test.js
+++ b/__snapshots__/app-create.test.js
@@ -50,7 +50,7 @@ kinvey app create <name>
 Create an application
 
 Positionals:
-  name  App name                                                      [required]
+  name  App name                                             [string] [required]
 
 Options:
   --version                                 Show version number        [boolean]

--- a/__snapshots__/app-create.test.js
+++ b/__snapshots__/app-create.test.js
@@ -2,8 +2,8 @@ exports['app create with a name and existent org identifier (ID) should succeed 
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
 [debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
-[debug] Request:  GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9
-[debug] Response: GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9 200
+[debug] Request:  GET http://localhost:3234/v3/organizations
+[debug] Response: GET http://localhost:3234/v3/organizations 200
 [debug] Request:  POST http://localhost:3234/v3/apps
 [debug] Response: POST http://localhost:3234/v3/apps 201
 Created application: 885f5d307afd4168bebca1a64f815c1e

--- a/__snapshots__/env-create.test.js
+++ b/__snapshots__/env-create.test.js
@@ -54,7 +54,7 @@ kinvey appenv create <name>
 Create an environment
 
 Positionals:
-  name  Env name                                                      [required]
+  name  Env name                                             [string] [required]
 
 Options:
   --version                                 Show version number        [boolean]
@@ -106,7 +106,7 @@ kinvey appenv create <name>
 Create an environment
 
 Positionals:
-  name  Env name                                                      [required]
+  name  Env name                                             [string] [required]
 
 Options:
   --version                                 Show version number        [boolean]

--- a/__snapshots__/flex-create.test.js
+++ b/__snapshots__/flex-create.test.js
@@ -170,12 +170,6 @@ Arguments app and org are mutually exclusive
 
 `
 
-exports['flex create with active profile without an app and org should fail 1'] = `
-[error] Either '--app' or '--org' option must be set.
-
-`
-
-
 exports['flex create with active profile without a name should fail 1'] = `
 kinvey flex create <name>
 
@@ -235,8 +229,8 @@ exports['flex create with one-time session with name, secret and org should succ
 [debug] Request:  POST http://localhost:3234/session
 [debug] Response: POST http://localhost:3234/session 200
 [debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
-[debug] Request:  GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9
-[debug] Response: GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9 200
+[debug] Request:  GET http://localhost:3234/v3/organizations
+[debug] Response: GET http://localhost:3234/v3/organizations 200
 [debug] Request:  POST http://localhost:3234/v3/services
 [debug] Response: POST http://localhost:3234/v3/services 201
 [debug] Request:  POST http://localhost:3234/v3/services/12378kdl2/environments

--- a/__snapshots__/flex-list.test.js
+++ b/__snapshots__/flex-list.test.js
@@ -87,8 +87,8 @@ exports['flex list by specifying a profile and valid options (org and id) should
 [debug] Using profile 'profileToGetServices'
 [debug] Project configuration file not found: 'projectSetupPath'.
 [debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
-[debug] Request:  GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9
-[debug] Response: GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9 200
+[debug] Request:  GET http://localhost:3234/v3/organizations
+[debug] Response: GET http://localhost:3234/v3/organizations 200
 [debug] Request:  GET http://localhost:3234/v3/services
 [debug] Response: GET http://localhost:3234/v3/services 200
 {

--- a/__snapshots__/org-show.test.js
+++ b/__snapshots__/org-show.test.js
@@ -1,59 +1,14 @@
-exports['org show when no active org with existent org id as option should output default format 1'] = `
+exports['org show when active org with credentials as options and existent name should succeed 1'] = `
 [debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
-[debug] Request:  GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9
-[debug] Response: GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9 200
-key                       value                           
-------------------------  --------------------------------
-id                        f71b0d5e60684b48b8265e7fa50302b9
-name                      My Team                         
-plan                      enterprise                      
-requireApprovals          true                            
-requireEmailVerification  false                           
-requireTwoFactorAuth      false                           
-
-
-`
-
-exports['org show when no active org with existent org id as option should output JSON 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
-[debug] Request:  GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9
-[debug] Response: GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9 200
-{
-  "result": {
-    "name": "My Team",
-    "creator": "39229488331a4af9046486a9bbfa5e8e",
-    "creationTime": "2017-06-21T19:49:15.784Z",
-    "restrictions": {
-      "defaultPlanLevel": "enterprise"
-    },
-    "security": {
-      "requireApprovals": true,
-      "requireEmailVerification": false,
-      "requireTwoFactorAuth": false
-    },
-    "id": "f71b0d5e60684b48b8265e7fa50302b9"
-  }
-}
-
-`
-
-exports['org show when no active org without id should return error 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[error] ItemNotSpecified: No organization identifier is specified and active organization is not set.
-
-`
-
-exports['org show when active org without id should succeed 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'activeProfile'
-[debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
-[debug] Request:  GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9
-[debug] Response: GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9 200
+[debug] Logging in user: janeyDoe@mail.com
+[debug] Request:  POST http://localhost:3234/session
+[debug] Response: POST http://localhost:3234/session 200
+[debug] Using organization: My Team
+[debug] Request:  GET http://localhost:3234/v3/organizations
+[debug] Response: GET http://localhost:3234/v3/organizations 200
+[debug] Request:  DELETE http://localhost:3234/session
+[debug] Response: DELETE http://localhost:3234/session 204
+[debug] Logged out current user.
 key                       value                           
 ------------------------  --------------------------------
 id                        f71b0d5e60684b48b8265e7fa50302b9
@@ -76,17 +31,12 @@ exports['org show when active org with non-existent org name should disregard ac
 
 `
 
-exports['org show when active org with credentials as options and existent name should succeed 1'] = `
+exports['org show when active org without id should succeed 1'] = `
 [debug] Checking for package updates
-[debug] Logging in user: janeyDoe@mail.com
-[debug] Request:  POST http://localhost:3234/session
-[debug] Response: POST http://localhost:3234/session 200
-[debug] Using organization: My Team
+[debug] Using profile 'activeProfile'
+[debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
 [debug] Request:  GET http://localhost:3234/v3/organizations
 [debug] Response: GET http://localhost:3234/v3/organizations 200
-[debug] Request:  DELETE http://localhost:3234/session
-[debug] Response: DELETE http://localhost:3234/session 204
-[debug] Logged out current user.
 key                       value                           
 ------------------------  --------------------------------
 id                        f71b0d5e60684b48b8265e7fa50302b9
@@ -96,5 +46,55 @@ requireApprovals          true
 requireEmailVerification  false                           
 requireTwoFactorAuth      false                           
 
+
+`
+
+exports['org show when no active org with existent org id as option should output JSON 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
+[debug] Request:  GET http://localhost:3234/v3/organizations
+[debug] Response: GET http://localhost:3234/v3/organizations 200
+{
+  "result": {
+    "name": "My Team",
+    "creator": "39229488331a4af9046486a9bbfa5e8e",
+    "creationTime": "2017-06-21T19:49:15.784Z",
+    "restrictions": {
+      "defaultPlanLevel": "enterprise"
+    },
+    "security": {
+      "requireApprovals": true,
+      "requireEmailVerification": false,
+      "requireTwoFactorAuth": false
+    },
+    "id": "f71b0d5e60684b48b8265e7fa50302b9"
+  }
+}
+
+`
+
+exports['org show when no active org with existent org id as option should output default format 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
+[debug] Request:  GET http://localhost:3234/v3/organizations
+[debug] Response: GET http://localhost:3234/v3/organizations 200
+key                       value                           
+------------------------  --------------------------------
+id                        f71b0d5e60684b48b8265e7fa50302b9
+name                      My Team                         
+plan                      enterprise                      
+requireApprovals          true                            
+requireEmailVerification  false                           
+requireTwoFactorAuth      false                           
+
+
+`
+
+exports['org show when no active org without id should return error 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'activeProfile'
+[error] ItemNotSpecified: No organization identifier is specified and active organization is not set.
 
 `

--- a/__snapshots__/org-use.test.js
+++ b/__snapshots__/org-use.test.js
@@ -1,26 +1,26 @@
-exports['org use by not specifying a profile when one should use it with existent org id should succeed and output default format 1'] = `
-[debug] Checking for package updates
-[debug] Using profile 'orgProfile0'
-[debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
-[debug] Request:  GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9
-[debug] Response: GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9 200
-[debug] Writing contents to file globalSetupPath
-Active organization: f71b0d5e60684b48b8265e7fa50302b9
-
-`
-
 exports['org use by not specifying a profile when one should use it with existent org id should succeed and output JSON 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'orgProfile0'
 [debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
-[debug] Request:  GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9
-[debug] Response: GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9 200
+[debug] Request:  GET http://localhost:3234/v3/organizations
+[debug] Response: GET http://localhost:3234/v3/organizations 200
 [debug] Writing contents to file globalSetupPath
 {
   "result": {
     "id": "f71b0d5e60684b48b8265e7fa50302b9"
   }
 }
+
+`
+
+exports['org use by not specifying a profile when one should use it with existent org id should succeed and output default format 1'] = `
+[debug] Checking for package updates
+[debug] Using profile 'orgProfile0'
+[debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
+[debug] Request:  GET http://localhost:3234/v3/organizations
+[debug] Response: GET http://localhost:3234/v3/organizations 200
+[debug] Writing contents to file globalSetupPath
+Active organization: f71b0d5e60684b48b8265e7fa50302b9
 
 `
 
@@ -49,8 +49,8 @@ exports['org use by specifying a profile should use it and succeed 1'] = `
 [debug] Checking for package updates
 [debug] Using profile 'profileToBeUsed'
 [debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
-[debug] Request:  GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9
-[debug] Response: GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9 200
+[debug] Request:  GET http://localhost:3234/v3/organizations
+[debug] Response: GET http://localhost:3234/v3/organizations 200
 [debug] Writing contents to file globalSetupPath
 Active organization: f71b0d5e60684b48b8265e7fa50302b9
 
@@ -60,8 +60,8 @@ exports['org use by specifying a profile when active is set and no profile optio
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
 [debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
-[debug] Request:  GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9
-[debug] Response: GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9 200
+[debug] Request:  GET http://localhost:3234/v3/organizations
+[debug] Response: GET http://localhost:3234/v3/organizations 200
 [debug] Writing contents to file globalSetupPath
 Active organization: f71b0d5e60684b48b8265e7fa50302b9
 
@@ -71,8 +71,8 @@ exports['org use by specifying a profile when active is set and profile specifie
 [debug] Checking for package updates
 [debug] Using profile 'profileToBeUsed'
 [debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
-[debug] Request:  GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9
-[debug] Response: GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9 200
+[debug] Request:  GET http://localhost:3234/v3/organizations
+[debug] Response: GET http://localhost:3234/v3/organizations 200
 [debug] Writing contents to file globalSetupPath
 Active organization: f71b0d5e60684b48b8265e7fa50302b9
 

--- a/__snapshots__/schema-validator.test.js
+++ b/__snapshots__/schema-validator.test.js
@@ -50,5 +50,5 @@ exports['schema validator service with invalid rapid data (sharepoint) should fa
 
 exports['schema validator service with invalid rapid data (wrong type) should fail 1'] = `
 
-	type: "type" must be one of [flex-internal, flex-external, rest, sharepoint, salesforce, mssql, sap, progressData, dataDirect, rapid-health]
+	type: "type" must be one of [flex-internal, flex-external, rest, sharepoint, salesforce, mssql, progressData, dataDirect, rapid-health]
 `

--- a/__snapshots__/website-create.test.js
+++ b/__snapshots__/website-create.test.js
@@ -20,8 +20,8 @@ exports['website create using active profile with a name and org ID should succe
 [debug] Checking for package updates
 [debug] Using profile 'activeProfile'
 [debug] Using organization: f71b0d5e60684b48b8265e7fa50302b9
-[debug] Request:  GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9
-[debug] Response: GET http://localhost:3234/v3/organizations/f71b0d5e60684b48b8265e7fa50302b9 200
+[debug] Request:  GET http://localhost:3234/v3/organizations
+[debug] Response: GET http://localhost:3234/v3/organizations 200
 [debug] Request:  POST http://localhost:3234/v3/sites
 [debug] Response: POST http://localhost:3234/v3/sites 201
 [debug] Request:  POST http://localhost:3234/v3/sites/9caf90c31c4449f195a1a40acc979cf0/environments

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -724,7 +724,6 @@ Constants.ConfigFiles.ServiceType = {
   SP: 'sharepoint',
   SF: 'salesforce',
   SQL: 'mssql',
-  SAP: 'sap',
   PROGRESS_DATA: 'progressData',
   DATA_DIRECT: 'dataDirect',
   POKIT_DOK: 'rapid-health'
@@ -737,7 +736,6 @@ Constants.BackendServiceType = {
   SP: 'sharepoint',
   SF: 'salesforce',
   SQL: 'mssql',
-  SAP: 'saprfc',
   PROGRESS_DATA: 'progressDataObject'
 };
 
@@ -756,7 +754,6 @@ Constants.ConfigFiles.BackendToConfigServiceType = {
   [Constants.BackendServiceType.SP]: Constants.ConfigFiles.ServiceType.SP,
   [Constants.BackendServiceType.SF]: Constants.ConfigFiles.ServiceType.SF,
   [Constants.BackendServiceType.SQL]: Constants.ConfigFiles.ServiceType.SQL,
-  [Constants.BackendServiceType.SAP]: Constants.ConfigFiles.ServiceType.SAP,
   [Constants.BackendServiceType.PROGRESS_DATA]: Constants.ConfigFiles.ServiceType.PROGRESS_DATA
 };
 

--- a/lib/SchemaValidator.js
+++ b/lib/SchemaValidator.js
@@ -245,7 +245,6 @@ const serviceSchemaKeys = {
     .when('type', { is: ConfigFiles.ServiceType.FLEX_EXTERNAL, then: flexExternalSrvEnvsSchema })
     .when('type', { is: ConfigFiles.ServiceType.SP, then: rapidSrvEnvsSchema })
     .when('type', { is: ConfigFiles.ServiceType.SF, then: rapidSrvEnvsSchema })
-    .when('type', { is: ConfigFiles.ServiceType.SAP, then: rapidSrvEnvsSchema })
     .when('type', { is: ConfigFiles.ServiceType.SQL, then: rapidSrvEnvsSchema })
     .when('type', { is: ConfigFiles.ServiceType.REST, then: rapidSrvEnvsSchema })
     .when('type', { is: ConfigFiles.ServiceType.PROGRESS_DATA, then: rapidSrvEnvsSchema })

--- a/lib/SchemaValidator.js
+++ b/lib/SchemaValidator.js
@@ -183,6 +183,7 @@ const rapidBaseSrvSchemaKeys = {
         getById: Joi.object(),
         getByQuery: Joi.object(),
         insert: Joi.object(),
+        insertMany: Joi.object(),
         update: Joi.object(),
         deleteById: Joi.object(),
         deleteByQuery: Joi.object(),

--- a/lib/application/applicationsRouter.js
+++ b/lib/application/applicationsRouter.js
@@ -22,7 +22,7 @@ const cmdDefinitions = [
     desc: 'Create an application',
     builder: (commandsManager) => {
       commandsManager
-        .positional('name', { describe: 'App name' })
+        .positional('name', { describe: 'App name', type: 'string' })
         .option('file', { describe: 'Path to an application configuration file' })
         .option(OrgOptionsName.ORG, OrgOptions[OrgOptionsName.ORG]);
     },

--- a/lib/environment/environmentsRouter.js
+++ b/lib/environment/environmentsRouter.js
@@ -22,7 +22,7 @@ const cmdDefinitions = [
     desc: 'Create an environment',
     builder: (commandsManager) => {
       commandsManager
-        .positional('name', { describe: 'Env name' })
+        .positional('name', { describe: 'Env name', type: 'string' })
         .option('file', { describe: 'Path to an environment configuration file' })
         .option(AppOptionsName.APP, AppOptions[AppOptionsName.APP]);
     },

--- a/lib/exporter/AppFileExporter.js
+++ b/lib/exporter/AppFileExporter.js
@@ -134,6 +134,11 @@ class AppFileExporter {
             const fileName = `${currService.name}.json`;
             this.serviceExporter.exportService({ service: currService, file: `${options.dir}/${fileName}` }, (err) => {
               if (err) {
+                if (err.message && err.message.includes('not supported')) {
+                  this.cliManager.log(LogLevel.WARN, `Skipped exporting service: ${currService.name}(${currService.id}). ${err.message}`);
+                  return cb();
+                }
+
                 return cb(err);
               }
 

--- a/lib/exporter/OrgFileExporter.js
+++ b/lib/exporter/OrgFileExporter.js
@@ -175,6 +175,11 @@ class OrgFileExporter {
             const filePath = `${options.dir}/${fileName}`;
             this.serviceExporter.exportService({ file: filePath, service: currService }, (err) => {
               if (err) {
+                if (err.message && err.message.includes('not supported')) {
+                  this.cliManager.log(LogLevel.WARN, `Skipped exporting service: ${currService.name}(${currService.id}). ${err.message}`);
+                  return cb();
+                }
+
                 return cb(err);
               }
 

--- a/lib/exporter/ServiceFileExporter.js
+++ b/lib/exporter/ServiceFileExporter.js
@@ -110,7 +110,7 @@ class ServiceFileExporter {
         if (!isEmpty(envMapping)) {
           const serviceObjectNames = Object.keys(envMapping);
           serviceObjectNames.forEach((serviceObjName) => {
-            delete envMapping[serviceObjName].backingServer;
+            delete envMapping[serviceObjName].serviceEnvironment;
             if (envMapping[serviceObjName].sourceObject) {
               // sometimes sourceObject contains more props than needed (e.g. IDs), so let's just take some
               const sourceObjProps = ['objectName', 'schemaName', 'objectType', 'primaryKey', 'name', 'endpoint',

--- a/lib/exporter/ServiceFileExporter.js
+++ b/lib/exporter/ServiceFileExporter.js
@@ -55,13 +55,16 @@ class ServiceFileExporter {
           }
 
           service = data;
-          const isSupported = AllowedServiceTypesForExport.includes(service.type);
-          if (!isSupported) {
-            return setImmediate(() => { next(new Error(`Type is not supported: ${service.type}.`)); });
-          }
-
           next();
         });
+      },
+      (next) => {
+        const isSupported = AllowedServiceTypesForExport.includes(service.type);
+        if (!isSupported) {
+          return setImmediate(() => { next(new Error(`Type is not supported: ${service.type}.`)); });
+        }
+
+        setImmediate(next);
       },
       (next) => {
         this.servicesService.getServiceEnvs(service.id, (err, data) => {

--- a/lib/organization/OrganizationsService.js
+++ b/lib/organization/OrganizationsService.js
@@ -14,25 +14,49 @@
  */
 
 const BaseService = require('./../BaseService');
-const { EntityType, HTTPMethod, LogLevel } = require('./../Constants');
-const { Endpoints, getCustomNotFoundError, getUsingEntityMsg, getTransformedError, isNotFoundError } = require('./../Utils');
+const { EntityType, Errors, HTTPMethod, LogLevel } = require('./../Constants');
+const { Endpoints, getCustomEntityError, getCustomNotFoundError, getUsingEntityMsg, isEmpty } = require('./../Utils');
 
 class OrganizationsService extends BaseService {
   getAll(done) {
     const endpoint = Endpoints.orgs(this.cliManager.config.defaultSchemaVersion);
-    super.getAllEntities(endpoint, done);
+    const queryForAllOrgs = { query: '{}' };
+    this.cliManager.sendRequest({ endpoint, query: queryForAllOrgs }, (err, allOrgs) => {
+      if (err) {
+        if (err.name !== 'InsufficientCredentials') {
+          return done(err);
+        }
+
+        return this.cliManager.sendRequest({ endpoint }, (err, orgsForUser) => {
+          if (err) {
+            return done(err);
+          }
+
+          return done(null, orgsForUser);
+        });
+      }
+
+      done(null, allOrgs);
+    });
   }
 
   getByIdOrName(identifier, done) {
-    const endpointAll = Endpoints.orgs(this.cliManager.config.defaultSchemaVersion);
-    const endpointId = Endpoints.orgs(this.cliManager.config.defaultSchemaVersion, identifier);
     this.cliManager.log(LogLevel.DEBUG, getUsingEntityMsg(EntityType.ORG, identifier));
-    super.getEntityByIdOrName(identifier, endpointAll, endpointId, (err, entity) => {
+    this.getAll((err, allOrgs) => {
       if (err) {
-        return done(getTransformedError(err, EntityType.ORG, identifier));
+        return done(err);
       }
 
-      done(null, entity);
+      const foundOrgs = allOrgs.filter(x => x.name === identifier || x.id === identifier);
+      if (isEmpty(foundOrgs)) {
+        return done(getCustomNotFoundError(EntityType.ORG, identifier));
+      }
+
+      if (foundOrgs.length > 1) {
+        return done(getCustomEntityError(EntityType.ORG, identifier, Errors.TooManyEntitiesFound.NAME));
+      }
+
+      done(null, foundOrgs[0]);
     });
   }
 

--- a/lib/service/servicesRouter.js
+++ b/lib/service/servicesRouter.js
@@ -22,7 +22,7 @@ const cmdDefinitions = [
     desc: 'Create a service',
     builder: (commandsManager) => {
       commandsManager
-        .positional('name', { describe: 'Service name' })
+        .positional('name', { describe: 'Service name', type: 'string' })
         .option('file', { describe: 'Path to a service configuration file' })
         .option(AppOptionsName.APP, AppOptions[AppOptionsName.APP])
         .option(OrgOptionsName.ORG, OrgOptions[OrgOptionsName.ORG])


### PR DESCRIPTION
The PR contains several small fixes and improvements for the GA release of the Config management feature:
* Allow creating app, app env or service with a name that contains only digits
* Do not export the `serviceEnvironment` field on the serviceObject during `service export`
* Fetch all orgs that a user can read
* Do not export services of type `custom`
* Remove support for SAP services as they are deprecated