### PR TITLE
Improve service type names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1137,13 +1137,13 @@ The following service templates can be used and modified as needed:
 }
 ```
 
-#### `rest` service sample config file
+#### `data-rest` service sample config file
 
 ```
 {
     "schemaVersion": "1.0.0",
     "configType": "service",
-    "type": "rest",
+    "type": "data-rest",
     "environments": {
         "Default": {
             "host": "http://www.test.com",
@@ -1235,7 +1235,7 @@ The following service templates can be used and modified as needed:
 
 `configType` *environment|service* The configuration type. Required.
 
-`type` *flex-internal|flex-external|rest|sharepoint|salesforce|mssql|progressData|dataDirect|rapid-health* Service type. Required.
+`type` *flex-internal|flex-external|data-rest|data-sharepoint|data-salesforce|data-mssql|data-progress|data-direct|data-health* Service type. Required.
  
 `description` Service description. String. Optional.
  
@@ -1243,19 +1243,19 @@ The following service templates can be used and modified as needed:
  
  `environments.[envName].secret` Shared secret to use when communicating with the service. Аpplicable and required for 'flex-internal' and 'flex-external'
  
-`environments.[envName].host` URI pointing to the service server's location. Required for all service types except 'flex-internal' and 'rapid-health'.
+`environments.[envName].host` URI pointing to the service server's location. Required for all service types except 'flex-internal' and 'data-health'.
 
 `environments.[envName].sourcePath` Path to source code - relative or absolute. Optional. Applicable when `type` is 'flex-internal'.
 
 `environments.[envName].runtime` The nodejs version of the runtime. Optional. The value must be one of [node6, node8, node10, node12]. Applicable when `type` is 'flex-internal'.
 
-`environments.[envName].authentication` Authentication type and credentials. Object. Optional. Applicable for 'rest', 'sharepoint', 'salesforce', 'mssql', 'progressData', 'dataDirect' and 'rapid-health' service types
+`environments.[envName].authentication` Authentication type and credentials. Object. Optional. Applicable for 'data-rest', 'data-sharepoint', 'data-salesforce', 'data-mssql', 'data-progress', 'data-direct' and 'data-health' service types
 
-`environments.[envName].connectionOptions` Connection options. Object. Optional. Applicable for 'rest', 'sharepoint', 'salesforce', 'mssql', 'progressData', 'dataDirect' and 'rapid-health' service types
+`environments.[envName].connectionOptions` Connection options. Object. Optional. Applicable for 'data-rest', 'data-sharepoint', 'data-salesforce', 'data-mssql', 'data-progress', 'data-direct' and 'data-health' service types.
 
-`environments.[envName].mapping` Contains the source object, the source fields mapping and the supported operations. Object. Optional. Applicable for 'rest', 'sharepoint', 'salesforce', 'mssql', 'progressData', 'dataDirect' and 'rapid-health' service types
+`environments.[envName].mapping` Contains the source object, the source fields mapping and the supported operations. Object. Optional. Applicable for 'data-rest', 'data-sharepoint', 'data-salesforce', 'data-mssql', 'data-progress', 'data-direct' and 'data-health' service types.
 
-`environments.[envName].version` The version of the source server. Object. Optional. Applicable when `type` is 'sharepoint' or 'mssql'.
+`environments.[envName].version` The version of the source server. Object. Optional. Applicable when `type` is 'data-sharepoint' or 'data-mssql'.
 
 `environments.[envName].environmentVariables` Environment variables. Object. Optional. Applicable when `type` is 'flex-internal'.
 

--- a/__snapshots__/schema-validator.test.js
+++ b/__snapshots__/schema-validator.test.js
@@ -50,5 +50,5 @@ exports['schema validator service with invalid rapid data (sharepoint) should fa
 
 exports['schema validator service with invalid rapid data (wrong type) should fail 1'] = `
 
-	type: "type" must be one of [flex-internal, flex-external, rest, sharepoint, salesforce, mssql, progressData, dataDirect, rapid-health]
+	type: "type" must be one of [flex-internal, flex-external, data-rest, data-sharepoint, data-salesforce, data-mssql, data-progress, data-direct, data-health]
 `

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -720,13 +720,13 @@ Constants.ConfigFiles.CollType = {
 Constants.ConfigFiles.ServiceType = {
   FLEX_INTERNAL: 'flex-internal',
   FLEX_EXTERNAL: 'flex-external',
-  REST: 'rest',
-  SP: 'sharepoint',
-  SF: 'salesforce',
-  SQL: 'mssql',
-  PROGRESS_DATA: 'progressData',
-  DATA_DIRECT: 'dataDirect',
-  POKIT_DOK: 'rapid-health'
+  REST: 'data-rest',
+  SP: 'data-sharepoint',
+  SF: 'data-salesforce',
+  SQL: 'data-mssql',
+  PROGRESS_DATA: 'data-progress',
+  DATA_DIRECT: 'data-direct',
+  POKIT_DOK: 'data-health'
 };
 
 Constants.BackendServiceType = {

--- a/test/fixtures/config-files/rapid-data-sp-invalid-some-options.json
+++ b/test/fixtures/config-files/rapid-data-sp-invalid-some-options.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0.0",
   "configType": "service",
-  "type": "sharepoint",
+  "type": "data-sharepoint",
   "environments": {
     "default": {
       "version": "online",

--- a/test/fixtures/config-files/rapid-data-sp-invalid.json
+++ b/test/fixtures/config-files/rapid-data-sp-invalid.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0.0",
   "configType": "service",
-  "type": "sharepointy",
+  "type": "data-sharepointy",
   "environments": {
     "default": {
       "version": "online",

--- a/test/fixtures/config-files/rapid-data-sp-valid-some-options.json
+++ b/test/fixtures/config-files/rapid-data-sp-valid-some-options.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0.0",
   "configType": "service",
-  "type": "sharepoint",
+  "type": "data-sharepoint",
   "environments": {
     "default": {
       "version": "online",

--- a/test/integration-no-mock/config-management/service-config-apply.js
+++ b/test/integration-no-mock/config-management/service-config-apply.js
@@ -241,7 +241,7 @@ module.exports = () => {
       const initialServiceConfig = {
         configType: 'service',
         schemaVersion: '1.0.0',
-        type: 'mssql',
+        type: 'data-mssql',
         environments: {
           dev: {
             version: '2008-r2',
@@ -310,7 +310,7 @@ module.exports = () => {
       const initialServiceConfig = {
         configType: 'service',
         schemaVersion: '1.0.0',
-        type: 'rest',
+        type: 'data-rest',
         environments: {
           dev: {
             connectionOptions: {

--- a/test/integration-no-mock/config-management/service-config-create.js
+++ b/test/integration-no-mock/config-management/service-config-create.js
@@ -227,7 +227,7 @@ module.exports = () => {
   describe('rapid data', () => {
     it('sharepoint with one environment and mapping should succeed', (done) => {
       const serviceName = randomStrings.plainString();
-      const serviceType = 'sharepoint';
+      const serviceType = 'data-sharepoint';
       const srvEnv = {
         version: 'online',
         authentication: {
@@ -308,7 +308,7 @@ module.exports = () => {
       const serviceConfig = {
         configType: 'service',
         schemaVersion: '1.0.0',
-        type: 'salesforce',
+        type: 'data-salesforce',
         environments: {
           dev: srvEnv
         }
@@ -333,7 +333,7 @@ module.exports = () => {
 
     it('sharepoint with two environments and mapping should succeed', (done) => {
       const serviceName = randomStrings.plainString();
-      const serviceType = 'sharepoint';
+      const serviceType = 'data-sharepoint';
       const srvEnv = {
         version: 'online',
         authentication: {

--- a/test/integration-no-mock/config-management/service-config-export.js
+++ b/test/integration-no-mock/config-management/service-config-export.js
@@ -156,7 +156,7 @@ module.exports = () => {
     const serviceConfig = {
       configType: 'service',
       schemaVersion: '1.0.0',
-      type: 'rest',
+      type: 'data-rest',
       environments: {
         default: {
           connectionOptions: {


### PR DESCRIPTION
Rename RapidData services to `data-X`. 
Example: `sharepoint` to `data-sharepoint`.