### PR TITLE
KDEV-1157: Do not update the env if no settings

### DIFF
--- a/lib/EnvFileProcessor.js
+++ b/lib/EnvFileProcessor.js
@@ -246,6 +246,12 @@ class EnvFileProcessor {
     async.series([
       (next) => {
         let envData = { name: source.name || env.name };
+        const isNameChanged = source.name != null && source.name !== env.name;
+        if (!isNameChanged && (source.settings == null || isEmpty(source.settings))) {
+          this.cliManager.log(LogLevel.INFO, `Skipping environment update: ${envData.name}`);
+          return next();
+        }
+
         envData = Object.assign(envData, source.settings);
         this.cliManager.log(LogLevel.INFO, `Updating environment: ${envData.name}`);
         this.environmentsService.update(envId, envData, next);


### PR DESCRIPTION
* Do not update the env when the `settings` field is missing from the config file on `kinvey appenv apply`.