### PR TITLE
KDEV-1308: Fix Validation error for collection hooks

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -655,9 +655,13 @@ Constants.Mapping[Constants.EntityType.ENV].DETAILS = Object.assign(
 );
 
 Constants.CollectionHook = {
+  onPreInsert: 'pre-insert',
+  onPreUpdate: 'pre-update',
   onPreSave: 'pre-save',
   onPreFetch: 'pre-fetch',
   onPreDelete: 'pre-delete',
+  onPostInsert: 'post-insert',
+  onPostUpdate: 'post-update',
   onPostSave: 'post-save',
   onPostFetch: 'post-fetch',
   onPostDelete: 'post-delete'

--- a/lib/RolesService.js
+++ b/lib/RolesService.js
@@ -19,7 +19,7 @@ const { HTTPMethod } = require('./Constants');
 class RolesService extends BaseService {
   static getAuthorizationHeaderValue(env) {
     const envIdMasterSecretPair = `${env.id}:${env.masterSecret}`;
-    const encodedEnvIdMasterSecretPair = (new Buffer(envIdMasterSecretPair)).toString('base64');
+    const encodedEnvIdMasterSecretPair = (Buffer.from(envIdMasterSecretPair)).toString('base64');
     return `Basic ${encodedEnvIdMasterSecretPair}`;
   }
 

--- a/package.json
+++ b/package.json
@@ -30,9 +30,8 @@
     "test-integration-mock": "./node_modules/.bin/mocha test/integration",
     "test-integration-no-mock": "./node_modules/.bin/mocha test/integration-no-mock/**/*.test.js",
     "test-integration": "npm run test-integration-mock && npm run test-integration-no-mock",
-    "coverage": "./node_modules/.bin/nyc --reporter=html --reporter=text ./node_modules/.bin/mocha test --NODE_CONFIG_DIR=./test/config",
     "eslint": "./node_modules/.bin/eslint bin config lib test",
-    "test-npm-security": "npm audit"
+    "test-npm-security": "npm audit --production --audit-level=high"
   },
   "dependencies": {
     "aes-js": "3.1.1",
@@ -76,7 +75,6 @@
     "eslint-plugin-import": "2.13.0",
     "express": "4.16.2",
     "mocha": "5.0.4",
-    "nyc": "13.1.0",
     "sinon": "4.1.3",
     "sinon-chai": "2.14.0",
     "snap-shot-it": "6.1.9",

--- a/test/ApiService.js
+++ b/test/ApiService.js
@@ -194,7 +194,7 @@ function getBaasAuthToken(envId, done) {
     }
 
     const envIdMasterSecretPair = `${env.id}:${env.masterSecret}`;
-    const encodedEnvIdMasterSecretPair = (new Buffer(envIdMasterSecretPair)).toString('base64');
+    const encodedEnvIdMasterSecretPair = (Buffer.from(envIdMasterSecretPair)).toString('base64');
     baasAuthTokens[envId] = encodedEnvIdMasterSecretPair;
     return done(null, baasAuthTokens[envId]);
   });

--- a/test/fixtures/config-files/env-valid-all-options.json
+++ b/test/fixtures/config-files/env-valid-all-options.json
@@ -52,13 +52,45 @@
   },
   "collectionHooks": {
     "colle2": {
+      "onPreInsert": {
+        "type": "internal",
+        "code": "function onPreInsert(request, response, modules) {\n  response.continue();\n}"
+      },
+      "onPreUpdate": {
+        "type": "internal",
+        "code": "function onPreUpdate(request, response, modules) {\n  response.continue();\n}"
+      },
       "onPreSave": {
         "type": "internal",
         "code": "function onPreSave(request, response, modules) {\n  response.continue();\n}"
       },
+      "onPreFetch": {
+        "type": "internal",
+        "code": "function onPreFetch(request, response, modules) {\n  response.continue();\n}"
+      },
+      "onPreDelete": {
+        "type": "internal",
+        "code": "function onPreDelete(request, response, modules) {\n  response.continue();\n}"
+      },
+      "onPostInsert": {
+        "type": "internal",
+        "code": "function onPostInsert(request, response, modules) {\n  response.continue();\n}"
+      },
+      "onPostUpdate": {
+        "type": "internal",
+        "code": "function onPostUpdate(request, response, modules) {\n  response.continue();\n}"
+      },
       "onPostSave": {
         "type": "internal",
-        "code": "function onPreSave(request, response, modules) {\n  response.continue();\n}"
+        "code": "function onPostSave(request, response, modules) {\n  response.continue();\n}"
+      },
+      "onPostFetch": {
+        "type": "internal",
+        "code": "function onPostFetch(request, response, modules) {\n  response.continue();\n}"
+      },
+      "onPostDelete": {
+        "type": "internal",
+        "code": "function onPostDelete(request, response, modules) {\n  response.continue();\n}"
       }
     },
     "colle0": {

--- a/test/integration-no-mock/config-management/org-config-apply.js
+++ b/test/integration-no-mock/config-management/org-config-apply.js
@@ -53,7 +53,9 @@ module.exports = () => {
           }
         },
         services: {},
-        settings: {}
+        settings: {
+          sessionTimeoutInSeconds: 1209600
+        }
       }
     },
     services: {


### PR DESCRIPTION
1) Added missing collection hook types as they resulted in ValidationError when trying to create/modify those collection hook types.
2) Updated to use recommended _Buffer.from()_ constructor to fix:
`DeprecationWarning: Buffer() is deprecated due to security and usability issues when I move my script to another server`